### PR TITLE
fix: broken login

### DIFF
--- a/lib/gtag.ts
+++ b/lib/gtag.ts
@@ -1,5 +1,6 @@
 import { NextRouter } from "next/router";
 import { GA_MEASUREMENT_ID } from "./constants";
+import { User } from "./shuttle";
 
 // https://developers.google.com/analytics/devguides/collection/ga4/event-parameters?client_type=gtag#set-up-every-event
 export const pageview = (url: string) => {
@@ -34,10 +35,16 @@ export const gtagConsent = () => {
   });
 };
 
-export const setupGoogleAnalytics = (router: NextRouter) => {
+export const setupGoogleAnalytics = (router: NextRouter, user: User) => {
   const handleRouteChange = (url: string) => {
     pageview(url);
   };
+
+  // set userId in GA session
+  if (typeof user !== "undefined") {
+    gtagUserId(user.name);
+  }
+
   router.events.on("routeChangeComplete", handleRouteChange);
   router.events.on("hashChangeComplete", handleRouteChange);
   return () => {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -30,8 +30,8 @@ config.autoAddCss = false;
 
 export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
-  useEffect(() => setupGoogleAnalytics(router));
   const { user } = pageProps;
+  useEffect(() => setupGoogleAnalytics(router, user));
 
   return (
     <UserProvider user={user}>

--- a/pages/api/auth/[...auth0].ts
+++ b/pages/api/auth/[...auth0].ts
@@ -14,9 +14,6 @@ async function afterCallback(req, res, session, state) {
     }
   });
 
-  // set the user ID in the google analytics session
-  gtagUserId(user.name);
-
   session.user.api_key = user.key;
 
   return session;


### PR DESCRIPTION
The login was broken by setting the gtag in the auth callback, since window was undefined. This sets in a global useffect instead, where the window should be defined.