### PR TITLE
Update for Shuttle 0.13, fix typo API route

### DIFF
--- a/_blog/2023-03-01-getting-started-with-rust-and-gpt.mdx
+++ b/_blog/2023-03-01-getting-started-with-rust-and-gpt.mdx
@@ -145,8 +145,8 @@ publish = false
 
 [dependencies]
 axum = "0.6.10"
-shuttle-axum = { version = "0.13.0" }
-shuttle-runtime = { version = "0.13.0" }
+shuttle-axum = { version = "0.14.0" }
+shuttle-runtime = { version = "0.14.0" }
 tokio = { version = "1.26.0" }
 ```
 

--- a/_blog/2023-03-01-getting-started-with-rust-and-gpt.mdx
+++ b/_blog/2023-03-01-getting-started-with-rust-and-gpt.mdx
@@ -160,10 +160,10 @@ axum-extra = { version = "0.5.0", features = ["spa"] }
 axum-macros = "0.3.4"
 openai-api = "0.1.4"
 serde = { version = "1.0.152", features = ["derive"] }
-shuttle-axum = { version = "0.13.0" }
-shuttle-runtime = { version = "0.13.0" }
-shuttle-secrets = "0.13.0"
-shuttle-static-folder = "0.13.0"
+shuttle-axum = { version = "0.14.0" }
+shuttle-runtime = { version = "0.14.0" }
+shuttle-secrets = "0.14.0"
+shuttle-static-folder = "0.14.0"
 tokio = { version = "1.26.0" }
 ```
 

--- a/_blog/2023-03-01-getting-started-with-rust-and-gpt.mdx
+++ b/_blog/2023-03-01-getting-started-with-rust-and-gpt.mdx
@@ -145,8 +145,8 @@ publish = false
 
 [dependencies]
 axum = "0.6.10"
-shuttle-axum = { version = "0.12.0" }
-shuttle-runtime = { version = "0.12.0" }
+shuttle-axum = { version = "0.13.0" }
+shuttle-runtime = { version = "0.13.0" }
 tokio = { version = "1.26.0" }
 ```
 
@@ -160,10 +160,10 @@ axum-extra = { version = "0.5.0", features = ["spa"] }
 axum-macros = "0.3.4"
 openai-api = "0.1.4"
 serde = { version = "1.0.152", features = ["derive"] }
-shuttle-axum = { version = "0.12.0" }
-shuttle-runtime = { version = "0.12.0" }
-shuttle-secrets = "0.12.0"
-shuttle-static-folder = "0.12.0"
+shuttle-axum = { version = "0.13.0" }
+shuttle-runtime = { version = "0.13.0" }
+shuttle-secrets = "0.13.0"
+shuttle-static-folder = "0.13.0"
 tokio = { version = "1.26.0" }
 ```
 
@@ -199,7 +199,7 @@ async fn axum(
 Let's have a look at what our API route would look like:
 
 ```rust
-// main.rs
+// router.rs
 pub async fn generate_prompt(State(state): State<AppState>) -> impl IntoResponse {
 
     let prompt = "Generate a random name.


### PR DESCRIPTION
Hello,

I found a typo in the code snippet that introduces the route handler function. The comment line at the top was incorrect.  I also updated the discussion of the dependencies to show reference to version 0.13 instead of 0.12.

I updated the companion repo and opened a PR for Josh to review.

Cheers,

~Jeff Mitchell