### PR TITLE
fix: Text-overflow in the FAQ section

### DIFF
--- a/components/sections/FrequentlyAskedQuestions.tsx
+++ b/components/sections/FrequentlyAskedQuestions.tsx
@@ -49,7 +49,7 @@ const FrequentlyAskedQuestions: FC<FrequentlyAskedQuestionsProps> = ({ questions
 									className={clsx(
 										'text-[#525151] transition-all duration-500 dark:text-[#C2C2C2]',
 										activeQuestion === index
-											? 'max-h-48 pb-5 pr-5 opacity-100'
+											? 'pb-5 pr-5 opacity-100'
 											: 'max-h-0 overflow-hidden pb-0 pr-0 opacity-0'
 									)}
 								>


### PR DESCRIPTION
This PR intends to patch the overflowing text in the [FrequentlyAskedQuestions](https://github.com/shuttle-hq/www/blob/1b9b41285e248d8674d83da08451468ed7bb0f68/components/sections/FrequentlyAskedQuestions.tsx) component on small-screen devices by removing the set max-height bound.

Current behaviour:
![Screenshot_20230408-205606_Brave~2](https://user-images.githubusercontent.com/46051506/230729977-bf9311de-2f5b-40cd-bb0a-290407ad3287.png)

After the patch:
![Screenshot_20230408-210343_Brave~2](https://user-images.githubusercontent.com/46051506/230729991-26bd3a32-744d-4980-804d-68b17ebe2e25.png)
