### PR TITLE
fix: correctly copy `::` in code examples 

### DIFF
--- a/pages/launchpad/issues/[slug].tsx
+++ b/pages/launchpad/issues/[slug].tsx
@@ -87,18 +87,17 @@ export async function getStaticProps({
 const Pre = ({ children, ...props }: any) => {
 	let line = 0
 
-	const code = useMemo(() => {
-		return [children.props.children]
-			.flat()
-			.flatMap((child) => {
-				if (typeof child !== 'string') {
-					return child.props.children
-				} else {
-					return child
-				}
-			})
-			.join('')
-	}, [children])
+	function getChildren(children: any): string[] {
+		return [children].flat().flatMap((child: any) => {
+			if (typeof child === 'string') {
+				return child
+			}
+
+			return getChildren(child.props.children)
+		})
+	}
+
+	const code = getChildren(children.props.children).join('')
 
 	return (
 		<div className={clsx('relative')}>


### PR DESCRIPTION
Fixes #87 