### PR TITLE
refactor: Remove Rust mid engineer job position

### DIFF
--- a/content/jobs.ts
+++ b/content/jobs.ts
@@ -8,11 +8,7 @@ export const Jobs: PositionProps[] = [
 	{
 		name: 'Technical Product Manager',
 		link: 'https://www.ycombinator.com/companies/shuttle/jobs/ruT34pf-technical-product-manager',
-	},
-	{
-		name: 'Rust Engineer (Mid)',
-		link: 'https://www.ycombinator.com/companies/shuttle/jobs/2II1ldn-rust-engineer-mid',
-	},
+	}
 ]
 
 export default Jobs


### PR DESCRIPTION
The job position doesn't exist anymore