### PR TITLE
feat: Modify Mastodon Share button to work with arbitrary instances

### DIFF
--- a/pages/blog/[year]/[month]/[day]/[slug].tsx
+++ b/pages/blog/[year]/[month]/[day]/[slug].tsx
@@ -295,9 +295,17 @@ export default function BlogPostPage(props: Props) {
 								<LinkedInLogo />
 							</a>
 							<a
-								href={`https://mastodon.social/share?text=${encodeURIComponent(
-									`${props.blog.title} ${SITE_URL}blog/${props.blog.slug}`
-								)}`}
+								href='#'
+								onClick={(e) => {
+									e.preventDefault()
+
+									const instance = window.prompt('Enter your Mastodon instance:')
+									if (instance) {
+										window.location.href = `https://${instance}/share?text=${encodeURIComponent(
+											`${props.blog.title} ${SITE_URL}blog/${props.blog.slug}`
+										)}`
+									}
+								}}
 								className='flex items-center rounded-xl border border-black/10 bg-black p-3 dark:border-white/10'
 								target='_blank'
 								rel='noreferrer'

--- a/pages/blog/[year]/[month]/[day]/[slug].tsx
+++ b/pages/blog/[year]/[month]/[day]/[slug].tsx
@@ -299,7 +299,7 @@ export default function BlogPostPage(props: Props) {
 								onClick={(e) => {
 									e.preventDefault()
 
-									const instance = window.prompt('Enter your Mastodon instance:')
+									const instance = window.prompt('Enter your Mastodon instance (ex. mastodon.social):')
 									if (instance) {
 										window.location.href = `https://${instance}/share?text=${encodeURIComponent(
 											`${props.blog.title} ${SITE_URL}blog/${props.blog.slug}`


### PR DESCRIPTION
Right now the share button assumes that the Mastodon instance you want to share the article on is `mastodon.social`.   
The PR prompts the user (using the naive `window.prompt` method) to ask the user which instance they want to share the post to.