### PR TITLE
refactor: We're not at EuroRust anymore

### DIFF
--- a/_launchpad/2023-10-17-issue-10-Serving-HTML.mdx
+++ b/_launchpad/2023-10-17-issue-10-Serving-HTML.mdx
@@ -214,11 +214,6 @@ Now it's your turn to crank up our little demo to produce a full-fledged website
 $ cargo shuttle deploy
 ```
 
-## EuroRust
-
-Stefan and the Shuttle crew will be at EuroRust October 11-12. If you are around, be sure to say hi and have a chat!
-
-
 ## Time for your feedback!
 
 We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://btl1d1x5z23.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.


### PR DESCRIPTION
Removes the part where we talk about being at EuroRust, because it's already too far in the future.