### PR TITLE
Updated the typeform urls

### DIFF
--- a/_launchpad/2023-03-07-issue-03-Ownership-Error-Handling.mdx
+++ b/_launchpad/2023-03-07-issue-03-Ownership-Error-Handling.mdx
@@ -265,7 +265,7 @@ _If you're stuck somewhere, join our Discord channel and ask at [#launchpad](htt
 
 ## Time for your feedback!
 
-We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://btl1d1x5z23.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
+We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://shuttlerust.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
 
 ## Join us!
 

--- a/_launchpad/2023-06-16-issue-01-Getting-Started.mdx
+++ b/_launchpad/2023-06-16-issue-01-Getting-Started.mdx
@@ -186,7 +186,7 @@ That's your start into Rust and Axum. From there on, we will implement some fun 
 
 ## Time for your feedback!
 
-We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://btl1d1x5z23.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
+We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://shuttlerust.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
 
 ## Join us!
 

--- a/_launchpad/2023-06-16-issue-02-Structs-and-Enums.mdx
+++ b/_launchpad/2023-06-16-issue-02-Structs-and-Enums.mdx
@@ -304,7 +304,7 @@ And that's it! You just deployed a podcast web application to the cloud! 🎉
 
 Let us quickly reiterate what we have learned:
 
-- Structs are used to group related data together. 
+- Structs are used to group related data together.
 - Enums are used to define a type that can have multiple variants. Each variant can have different data associated with it.
 -  Both can have `impl` blocks, which allow us to define methods on the struct or enum.
 - `Option` is an enum that can either be `Some` or `None`. It is used to represent the absence of a value.
@@ -314,7 +314,7 @@ Btw. the app looks a little bleak, give it some beautiful styles! You can find t
 
 ## Time for your feedback!
 
-We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://btl1d1x5z23.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
+We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://shuttlerust.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
 
 ## Join us!
 

--- a/_launchpad/2023-07-14-issue-04-Ownership-Lifetimes.mdx
+++ b/_launchpad/2023-07-14-issue-04-Ownership-Lifetimes.mdx
@@ -122,7 +122,7 @@ type SharedState = Arc<Mutex<SmallRng>>;
 
 #[shuttle_runtime::main]
 async fn axum() -> shuttle_axum::ShuttleAxum {
-    let state = 
+    let state =
          Arc::new(Mutex::new(SmallRng::from_entropy()));
     let router = Router::new()
         .route("/lotto/:pot/:amount", get(handler_lotto))
@@ -189,7 +189,7 @@ async fn handler_lotto(
     Extension(state): Extension<SharedState>,
 ) -> impl IntoResponse {
     let mut rng = state.lock().await;
-    let mut lotto: Lotto<'_, SmallRng> = 
+    let mut lotto: Lotto<'_, SmallRng> =
         Lotto::new(pot_size, &mut rng);
     let results = lotto.take(amount);
     Json(results)
@@ -200,7 +200,7 @@ Now you can re-use `Lotto` for every possible random number generator from the `
 
 ## Time for your feedback!
 
-We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://btl1d1x5z23.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
+We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://shuttlerust.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
 
 ## Join us!
 

--- a/_launchpad/2023-10-17-issue-10-Serving-HTML.mdx
+++ b/_launchpad/2023-10-17-issue-10-Serving-HTML.mdx
@@ -216,7 +216,7 @@ $ cargo shuttle deploy
 
 ## Time for your feedback!
 
-We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://btl1d1x5z23.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
+We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://shuttlerust.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
 
 ## Join us!
 

--- a/_launchpad/2023-11-08-issue-06-CRUD-Postgres.mdx
+++ b/_launchpad/2023-11-08-issue-06-CRUD-Postgres.mdx
@@ -3,7 +3,7 @@ title: "Issue #6: A little CRUD"
 date: "2023-08-11T16:00:00"
 ---
 
-# Shuttle Launchpad #6: A little CRUD 
+# Shuttle Launchpad #6: A little CRUD
 
 Welcome to Shuttle Launchpad Issue #6! This time, we want to apply all the learnings from the previous issues to create something that you might do a lot when writing backends: CRUD APIs. CRUD stands for "Create, read, update, delete", and is a pattern to manage database records via HTTP APIs. In doing so, we also learn about how to use a PostgreSQL database in Shuttle, and how the `sqlx` crate works. Have fun!
 
@@ -245,7 +245,7 @@ Good luck, and don't forget to share your results!
 
 ## Time for your feedback!
 
-We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://btl1d1x5z23.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
+We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://shuttlerust.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
 
 ## Join us!
 

--- a/_launchpad/2023-12-09-issue-08-websockets-chat.mdx
+++ b/_launchpad/2023-12-09-issue-08-websockets-chat.mdx
@@ -323,7 +323,7 @@ And that's all for today!
 
 ## Time for your feedback!
 
-We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://btl1d1x5z23.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
+We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://shuttlerust.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
 
 ## Join us!
 

--- a/_launchpad/2023-17-11-issue-11-12-testing-axum-applications.mdx
+++ b/_launchpad/2023-17-11-issue-11-12-testing-axum-applications.mdx
@@ -276,7 +276,7 @@ And much more! And don't forget to share your results with us! Write an app, and
 
 ## Time for your feedback!
 
-We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://btl1d1x5z23.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
+We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://shuttlerust.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
 
 ## Join us!
 

--- a/_launchpad/2023-22-09-issue-09-custom-validation.mdx
+++ b/_launchpad/2023-22-09-issue-09-custom-validation.mdx
@@ -250,7 +250,7 @@ From here on you can do a lot more. Now that you have a validated JSON input, yo
 
 ## Time for your feedback!
 
-We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://btl1d1x5z23.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
+We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://shuttlerust.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
 
 ## Join us!
 

--- a/_launchpad/2023-28-07-issue-05-Traits-Image-Processing.mdx
+++ b/_launchpad/2023-28-07-issue-05-Traits-Image-Processing.mdx
@@ -184,7 +184,7 @@ And keep the program ready. Next time, we try to improve it even further!
 
 ## Time for your feedback!
 
-We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://btl1d1x5z23.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
+We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://shuttlerust.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
 
 ## Join us!
 

--- a/_launchpad/2023-28-08-issue-07-more-CRUD.mdx
+++ b/_launchpad/2023-28-08-issue-07-more-CRUD.mdx
@@ -190,7 +190,7 @@ What could you do next? What about
 
 ## Time for your feedback!
 
-We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://btl1d1x5z23.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
+We want to tailor Shuttle Launchpad to your needs! [Give us feedback](https://shuttlerust.typeform.com/to/dTU2F8jI) on the most recent issue and your wishes here.
 
 ## Join us!
 

--- a/components/sections/ShuttleAI/Waitlist.tsx
+++ b/components/sections/ShuttleAI/Waitlist.tsx
@@ -24,7 +24,7 @@ export const Waitlist: FC<WaitListProps> = ({ cta, description, subDescription }
 			<p className='mt-8 max-w-2xl text-center text-xl text-[#7A7A7A]'>{description}</p>
 			<div className='mt-10 flex flex-col items-center justify-center text-center font-gradual text-lg font-bold sm:flex-row'>
 				<Link
-					href='https://btl1d1x5z23.typeform.com/shuttle-ai'
+					href='https://shuttlerust.typeform.com/shuttle-ai'
 					target='_blank'
 					className='mt-4 flex h-[56px] cursor-pointer items-center rounded-[14px] bg-[#D8D8D8] px-6 text-lg text-black sm:mt-0'
 					onClick={() => {

--- a/components/sections/ShuttleBatch/Countdown.tsx
+++ b/components/sections/ShuttleBatch/Countdown.tsx
@@ -33,7 +33,7 @@ export const Countdown = () => {
 						variant='primary'
 						invertOnDark
 						className='bg-[#13292C] text-white'
-						href='https://btl1d1x5z23.typeform.com/shuttle-batch-2'
+						href='https://shuttlerust.typeform.com/shuttle-batch-2'
 					>
 						Apply now
 					</Button>

--- a/components/sections/ShuttleBatch/Testimonials.tsx
+++ b/components/sections/ShuttleBatch/Testimonials.tsx
@@ -37,7 +37,7 @@ export const Testimonials = () => {
 						variant='primary'
 						invertOnDark
 						className='bg-[#13292C] text-white'
-						href='https://btl1d1x5z23.typeform.com/shuttle-batch-2'
+						href='https://shuttlerust.typeform.com/shuttle-batch-2'
 					>
 						Apply now
 					</Button>

--- a/components/sections/ShuttleHeroesHero.tsx
+++ b/components/sections/ShuttleHeroesHero.tsx
@@ -19,7 +19,7 @@ const ShuttleHeroesHero = () => {
 							variant='primary'
 							invertOnDark
 							className='bg-[#13292C] text-white'
-							href='https://btl1d1x5z23.typeform.com/to/WAu53vBi'
+							href='https://shuttlerust.typeform.com/to/WAu53vBi'
 							onClick={() => {
 								trackEvent('heroes_becomeahero')
 							}}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -18,7 +18,7 @@ export const GITHUB_URL = 'https://github.com/shuttle-hq/shuttle'
 
 export const GITHUB_EXAMPLES_URL = 'https://github.com/shuttle-hq/examples'
 
-export const CONTACT_US_URI = 'https://btl1d1x5z23.typeform.com/shuttle-pro'
+export const CONTACT_US_URI = 'https://shuttlerust.typeform.com/shuttle-pro'
 export const GET_STARTED_URI = 'https://console.shuttle.rs/account/billing'
 
 export const DISCORD_URL = 'https://discord.gg/shuttle'


### PR DESCRIPTION
I applied to be a Shuttle Hero earlier and noticed that the typeform URL had a redirect. I changed it to the new URL it recommended. Since I already cloned the repo earlier thought i'd change it over! I also decided to take a look and change the other URLs I could find. I don't know if they're still in use, but I wanted to grab them. Also, my IDE did some whitespace changes, and Lint didn't fix it. If I need to, I can go back and edit those out. Thanks!

<img width="334" alt="image" src="https://github.com/shuttle-hq/www/assets/20476157/b13cf080-dcf0-4053-893d-20b463c97b24">
