### PR TITLE
fix: article wording

### DIFF
--- a/_blog/2024-05-30-semantic-caching-qdrant-rust.mdx
+++ b/_blog/2024-05-30-semantic-caching-qdrant-rust.mdx
@@ -331,6 +331,7 @@ impl RagSystem {
             vector: embedding,
             limit: 1,
             with_payload: Some(payload_selector),
+            score_threshold: Some(0.35f32),
             ..Default::default()
         };
 


### PR DESCRIPTION
Amends a code snippet to include score threshold as required for `ScorePoints`.