### PR TITLE
Simple web server blog fixes

### DIFF
--- a/_blog/2024-03-13-simple-web-server-rust.mdx
+++ b/_blog/2024-03-13-simple-web-server-rust.mdx
@@ -192,7 +192,7 @@ use axum::{extract::State, http::StatusCode};
 async fn hello_world(
     State(state): State<MyState>
 ) -> StatusCode {
-    sqlx::query("SELECT 'Hello world!")
+    sqlx::query("SELECT 'Hello world!'")
          .execute(&state.db)
          .await
          .unwrap();

--- a/_blog/2024-03-13-simple-web-server-rust.mdx
+++ b/_blog/2024-03-13-simple-web-server-rust.mdx
@@ -142,6 +142,10 @@ Using databases generally isn’t much different in Rust than any other language
 
 Here’s an example of how you can do exactly that, using SQLx with Postgres as example. We initialise the `PgPool`, initialise our state struct and attach it to the router. 
 
+```bash
+cargo add sqlx -F postgres
+```
+
 ```rust
 use sqlx::PgPool;
 use axum::{extract::State, Router, routing::get, http::StatusCode};

--- a/_blog/2024-03-13-simple-web-server-rust.mdx
+++ b/_blog/2024-03-13-simple-web-server-rust.mdx
@@ -78,7 +78,7 @@ async fn main() -> shuttle_axum::ShuttleAxum {
 
 ## Routing
 
-HTTP responses from routing within Rust frameworks can be done by anything that implements a trait that represents a HTTP response. In Axum, this would be the `IntoResponse` trait (or `IntoResponseParts` for headers and other non-response body parts). Web servers can only return things that are valid HTTP responses. Implementing `IntoResponse` (and `IntoResponseParts` respectively) ensures this!
+HTTP responses from routing within Rust frameworks can be done by anything that implements a trait that represents a HTTP response. In Axum, this would be the `axum::response::IntoResponse` trait (or `axum::response::IntoResponseParts` for headers and other non-response body parts). Web servers can only return things that are valid HTTP responses. Implementing `IntoResponse` (and `IntoResponseParts` respectively) ensures this!
 
 It is possible to use `impl IntoResponse` as the return type for a function (for convenience). However, we would need to make sure all of the responses are of the same type. This can lead to confusion later down the line, particularly if you’re working in a team.
 

--- a/_blog/2024-03-13-simple-web-server-rust.mdx
+++ b/_blog/2024-03-13-simple-web-server-rust.mdx
@@ -93,6 +93,15 @@ async fn return_some_json() -> Json<Value> {
 
     Json(json)
 }
+
+#[shuttle_runtime::main]
+async fn main() -> shuttle_axum::ShuttleAxum {
+    let router = Router::new()
+        .route("/", get(hello_world))
+        .route("/json/", get(return_some_json));
+
+    Ok(router.into())
+}
 ```
 
 However, a more likely situation is that you’ll want to return data that follows a schema. We can use the `Deserialize` and `Serialize` traits from the `serde` crate to do this.  We can easily apply these traits by adding the `derive` feature and then adding it as a derive macro to a struct:

--- a/_blog/2024-03-13-simple-web-server-rust.mdx
+++ b/_blog/2024-03-13-simple-web-server-rust.mdx
@@ -137,11 +137,22 @@ Extractors are handler function arguments. They extract parts of the HTTP reques
 Here is an example of how you can use extractors. Note here that we use de-structuring to automatically get the inner variable in `Json<MyStruct>` as it looks cleaner.
 
 ```rust
+use axum::routing::post;
 
 async fn function_with_extractors(
     Json(json): Json<MyStruct>,
 ) -> impl IntoResponse {
     format!("The contents of my_field is: {}", json.my_field)
+}
+
+#[shuttle_runtime::main]
+async fn main() -> shuttle_axum::ShuttleAxum {
+    let router = Router::new()
+        .route("/", get(hello_world))
+        .route("/json/", get(return_some_json))
+        .route("/json-struct/", post(function_with_extractors));
+
+    Ok(router.into())
 }
 ```
 


### PR DESCRIPTION
I was going through the https://www.shuttle.rs/blog/2024/03/13/simple-web-server-rust blog post and ran into a few issues, which I've fixed in this PR.

I also ran into an incompatibility between the latest version of SQLx and shuttle-shared-db, which I fixed by downgrading SQLx to version 0.7.1.
