### PR TITLE
refactor: make all articles use new platform

### DIFF
--- a/_blog/2022-08-11-authentication-tutorial.mdx
+++ b/_blog/2022-08-11-authentication-tutorial.mdx
@@ -22,7 +22,7 @@ This isn't verified to be secure, use it at your own risk!!
 
 ## Let's get started
 
-First, we will install shuttle for creating the project (and later for deployment). If you don't already have it you can install it with `cargo install cargo-shuttle`. We will first go to a new directory for our project and create a new Axum app with `cargo shuttle init --axum`.
+First, we will install shuttle for creating the project (and later for deployment). If you don't already have it you can install it with `cargo install cargo-shuttle`. We will first go to a new directory for our project and create a new Axum app with `shuttle init --axum`.
 
 You should see the following in `src/lib.rs`:
 
@@ -159,7 +159,7 @@ let router = Router::new()
     .layer(Extension(Arc::new(tera)));
 ```
 
-With our main service we can now test it locally with `cargo shuttle run`.
+With our main service we can now test it locally with `shuttle run`.
 
 ![](/images/blog/authentication-demo-screenshot.png)
 
@@ -673,14 +673,9 @@ async fn axum(
 
 This is great, we now have a site with signup and login functionality. But we have no users, our friends can't log in on our localhost. We want it live on the interwebs. Luckily we are using shuttle, so it is as simple as:
 
-Create a project, this will start an isolated deployer container for you under the hood:
+To deploy your app, all you need to do is:
 ```
-cargo shuttle project start
-```
-
-Finally, to deploy your app, all you need to do is:
-```
-cargo shuttle deploy
+shuttle deploy
 ```
 
 Because of our `#[shuttle_service::main]` annotation and out-the-box Axum support our deployment doesn't need any prior config, it is instantly live!

--- a/_blog/2022-09-14-serenity-discord-bot.mdx
+++ b/_blog/2022-09-14-serenity-discord-bot.mdx
@@ -52,12 +52,12 @@ At this moment, our bot is not running because there is no code. We will have to
 
 ### [Serenity](https://docs.rs/serenity/latest/serenity/index.html)
 
-Serenity is a library for writing Discord bots (and communicating with the Discord API). We can create a new Serenity project which is readily deployable on shuttle with: `cargo shuttle init --serenity`
+Serenity is a library for writing Discord bots (and communicating with the Discord API). We can create a new Serenity project which is readily deployable on shuttle with: `shuttle init --serenity`
 
 If you don’t have shuttle yet, you can install it with `cargo install cargo-shuttle`. Afterwards, run the following in an empty directory:
 
 ```
-cargo shuttle init --serenity
+shuttle init --serenity
 ```
 
 After running it you, should see the following generated in `src/lib.rs`:
@@ -143,7 +143,7 @@ impl EventHandler for Bot {
 ```
 
 > Serenity has a bit of a different way of registering commands using a callback. If you are working on a larger command application, [poise](https://docs.rs/poise/latest/poise/) (which builds on Serenity) might be better suited.
-> 
+>
 
 With our command registered, we will now add a hook for when these commands are called using `interaction_create`.
 
@@ -186,7 +186,7 @@ DISCORD_TOKEN="*your discord token*"
 DISCORD_GUILD_ID="*the guild we are testing on*"
 ```
 
-`cargo shuttle run`
+`shuttle run`
 
 We should see that our bot now displays as online:
 
@@ -312,7 +312,7 @@ pub async fn get_forecast(
             place: place.to_owned(),
         })?;
 
-		// Now have the location combine the key/identifier with the URL 
+		// Now have the location combine the key/identifier with the URL
     let url = format!("{}{}?apikey={}", DAY_REQUEST, first_location.key, api_key);
 
 		let request = client.get(url).build().unwrap();
@@ -410,7 +410,7 @@ Now in the interaction handler, we can add a new branch to the match tree. We pu
 
     let value = argument.unwrap().value.unwrap();
     let place = value.as_str().unwrap();
-    let result = weather::get_forecast(place).await;		
+    let result = weather::get_forecast(place).await;
 
     match result {
         Ok((location, forecast)) => format!(
@@ -439,7 +439,7 @@ WEATHER_API_KEY="***"
 
 With the secrets added, we can run the server:
 
-`cargo shuttle run`
+`shuttle run`
 
 While typing, we should see our command come up with the options/parameters:
 
@@ -457,13 +457,9 @@ And entering a location that isn’t registered returns an error, thanks to the 
 
 With all of that setup, it is really easy to get your bot hosted and running without having to run your PC 24/7.
 
-Create a project, this will start an isolated deployer container for you under the hood:
+To deploy your app, all you need to do is:
 ```bash
-cargo shuttle project start
-```
-Finally, to deploy your app, all you need to do is:
-```bash
-cargo shuttle deploy
+shuttle deploy
 ```
 
 And you are good to go. Easy-pease, right?

--- a/_blog/2023-03-01-getting-started-with-rust-and-gpt.mdx
+++ b/_blog/2023-03-01-getting-started-with-rust-and-gpt.mdx
@@ -117,7 +117,7 @@ That's it! Our frontend is done. Now we can focus on the meat of the app, which 
 Ok so now that we're finished with our frontend, we can now write a backend that we'll be using for the prompt. We will want to use the following command to initialise our project:
 
 ```rust
-cargo shuttle init --axum
+shuttle init --axum
 ```
 
 You'll be prompted to enter a name for your project, where you want to initialise the directory (we will be calling this folder "API" for the sake of clarity) and whether or not you want to start a project environment on shuttle. On initialisation, we will be including Axum, which is a strong, easy to use framework.
@@ -337,7 +337,7 @@ Now our frontend assets will compile into the static folder of our Rust project,
 Now our app is ready to deploy, so once we're ready we can finalise the process by running the following command:
 
 ```rust
-cargo shuttle deploy
+shuttle deploy
 ```
 
 If there's no issues, it should deploy! We'll be able to view our app at the link that was given to us in the terminal, and it should work with no issues whatsoever.

--- a/_blog/2023-03-23-nextjs-and-rust.mdx
+++ b/_blog/2023-03-23-nextjs-and-rust.mdx
@@ -625,7 +625,7 @@ Now we're done with the programming section! We can finally look at deploying.
 
 ### Deployment
 
-Deploying with [shuttle](https://www.shuttle.dev), thankfully, is quite easy - you just need to run `npm run deploy` in the root directory of your project and if there aren't any issues, you should be able to see that shuttle has launched your app and it will return a list of information about your deployment followed by the database connection string for your shuttle-provisioned database. If you need to find this database string again, you can run `cargo shuttle status` in the backend directory of your project and it will find it for you.
+Deploying with [shuttle](https://www.shuttle.dev), thankfully, is quite easy - you just need to run `npm run deploy` in the root directory of your project and if there aren't any issues, you should be able to see that shuttle has launched your app and it will return a list of information about your deployment followed by the database connection string for your shuttle-provisioned database. If you need to find this database string again, you can run `shuttle resource list --show-secrets` in the backend directory of your project and it will find it for you.
 
 You may wish to run `cargo fmt` and `cargo clippy` before you deploy as any warnings or errors will appear while your web service is being built. If you don't have either of these components, you can use `rustup component add rustfmt` and `rustup component add clippy` respectively - both of these tools are a great addition to any Rust developer's toolbox and I would highly recommend using both of them.
 

--- a/_blog/2023-06-07-Shuttle-AI.mdx
+++ b/_blog/2023-06-07-Shuttle-AI.mdx
@@ -53,7 +53,7 @@ But enough talking, here’s that sneak peek we promised:
 
 Now, while this is just a small preview of our new tool’s capabilities, we will soon be opening it up to more testers, and we’re hyped to see what everyone will be able to build with it.
 
-And no worries - we’ve all seen generated code before and know how messy it can get. That’s why the generated code is standard Rust code and is completely human-readable and if you want to maintain it yourself, you will find it easy to understand and navigate. All of the infrastructure is provisioned via Shuttle, and your backend can also be ran locally using `cargo shuttle run`.
+And no worries - we’ve all seen generated code before and know how messy it can get. That’s why the generated code is standard Rust code and is completely human-readable and if you want to maintain it yourself, you will find it easy to understand and navigate. All of the infrastructure is provisioned via Shuttle, and your backend can also be ran locally using `shuttle run`.
 
 ### Choosing Rust
 

--- a/_blog/2023-07-28-turso-shuttle-integration-cats-api.mdx
+++ b/_blog/2023-07-28-turso-shuttle-integration-cats-api.mdx
@@ -59,7 +59,7 @@ cargo binstall cargo-shuttle
 After that, let’s initiate our app:
 
 ```rust
-cargo shuttle init
+shuttle init
 ```
 
 We can then follow the prompt to the end to create our app. This guide will assume you’re using the Axum starter template.
@@ -520,7 +520,7 @@ impl shuttle_runtime::Service for CustomService {
 
 ## Deployment
 
-Now that we’ve written everything, all you need to do is to use `cargo shuttle deploy` (add `--allow-dirty` if on a Git branch with uncommitted changes) and if there are no problems, you’ll be able to visit your web service at the provided URL in the terminal! The deployment at the end should look like something similar to this:
+Now that we’ve written everything, all you need to do is to use `shuttle deploy` (add `--allow-dirty` if on a Git branch with uncommitted changes) and if there are no problems, you’ll be able to visit your web service at the provided URL in the terminal! The deployment at the end should look like something similar to this:
 
 ![Preview of the cat facts API deployment](/images/blog/cat-facts-deployed.png)
 

--- a/_blog/2023-08-30-using-oauth-with-axum.mdx
+++ b/_blog/2023-08-30-using-oauth-with-axum.mdx
@@ -499,8 +499,6 @@ fn init_router(state: AppState, oauth_client: BasicClient, oauth_id: String) -> 
 ## Deploying to Production
 Once we're done implementing OAuth, all you need to do is use `cargo shuttle deploy` (with `--allow-dirty` if you're working on a dirty Git branch) and it'll work!
 
-If you didn't initialise your project on Shuttle servers before, make sure your project container is started. You can do so by running `cargo shuttle project start`.
-
 # Finishing Up
 Thanks for reading! I hope you enjoyed this guide to implementing OAuth in Rust and leveraging the [oauth2](https://github.com/ramosbugs/oauth2-rs) library for Rust auth.
 

--- a/_blog/2023-09-08-building-semantic-search-in-rust.mdx
+++ b/_blog/2023-09-08-building-semantic-search-in-rust.mdx
@@ -498,6 +498,6 @@ You need to:
 3. Get your Shuttle account! But I'm sure you have one already, don't you?
 4. [Install Shuttle](https://docs.shuttle.rs/getting-started/installation)
 
-Once you have everything, enter your access tokens to a `Secrets.toml` file and execute `cargo shuttle deploy` in your favorite command line.
+Once you have everything, enter your access tokens to a `Secrets.toml` file and execute `shuttle deploy` in your favorite command line.
 
 If you want to see the results upfront, check out [our video from the workshop we did together](https://www.youtube.com/watch?v=YLWSeiDh2o0)!

--- a/_blog/2023-09-27-rust-vs-go-comparison.mdx
+++ b/_blog/2023-09-27-rust-vs-go-comparison.mdx
@@ -1696,11 +1696,8 @@ We got rid of a lot of boilerplate code and can now deploy our app
 with ease.
 
 ```bash
-# We only need to run this once
-cargo shuttle project start
-
 # Run as often as you like
-cargo shuttle deploy
+shuttle deploy
 ```
 
 When it's done, it will print the URL to the service.

--- a/_blog/2023-10-16-graphql-in-rust.mdx
+++ b/_blog/2023-10-16-graphql-in-rust.mdx
@@ -20,7 +20,7 @@ Stuck or want to know what the final code looks like? [You can find the reposito
 
 You'll want to initiate a new Shuttle project (requires `cargo-shuttle`):
 ```bash
-cargo shuttle init
+shuttle init
 ```
 
 For this article we'll be using the project name "graphql-example". When the CLI asks you what framework you want, pick Axum.
@@ -90,7 +90,7 @@ pub async fn axum(
 }
 ```
 
-If we use `cargo shuttle run` to load up our program and go to `http://localhost:8000`, we should see the GraphQL playground.
+If we use `shuttle run` to load up our program and go to `http://localhost:8000`, we should see the GraphQL playground.
 
 Clicking the Queries on the left hand side will show us all the queries we can run - there should be one called "howdy" (which corresponds to the function we wrote under the Query implementation). You can verify it works by running it.
 
@@ -194,7 +194,7 @@ impl Dog {
     }
 }
 ```
-If you run `cargo shuttle run` and go to `http://localhost:8000`, you'll be able to see that if you click on Queries on the left-hand side, it'll let you use `dogs` as a query.
+If you run `shuttle run` and go to `http://localhost:8000`, you'll be able to see that if you click on Queries on the left-hand side, it'll let you use `dogs` as a query.
 
 ## Mutations
 
@@ -483,11 +483,11 @@ async fn shuttle_main(
 }
 ```
 
-If you use `cargo shuttle run` and go to `http://localhost:8000`, you'll be able to access all of your queries, mutations and the subscription we created.
+If you use `shuttle run` and go to `http://localhost:8000`, you'll be able to access all of your queries, mutations and the subscription we created.
 
 ## Deployment
 
-Once you're done, feel free to deploy by using `cargo shuttle deploy` (with `--allow-dirty` if on a dirty Git branch). Your app will then be deployed to Shuttle servers along with a provisioned database - nothing more is needed! When finished, you'll be able to view your connection string (if you lose it for whatever reason, you can use `cargo-shuttle resource list` to get the connection string again).
+Once you're done, feel free to deploy by using `shuttle deploy` (with `--allow-dirty` if on a dirty Git branch). Your app will then be deployed to Shuttle servers along with a provisioned database - nothing more is needed! When finished, you'll be able to view your connection string (if you lose it for whatever reason, you can use `cargo-shuttle resource list` to get the connection string again).
 
 If you're looking for something a bit more isolated, we also offer a completely isolated AWS RDS database as a paid add-on. Find out more about our pricing [here.](https://www.shuttle.dev/pricing)
 

--- a/_blog/2023-10-25-htmx-with-rust.mdx
+++ b/_blog/2023-10-25-htmx-with-rust.mdx
@@ -2,7 +2,7 @@
 title: "htmx, Rust & Shuttle: A New Rapid Prototyping Stack"
 description: This article details how htmx with Rust and Shuttle can speed up your workflow and let you focus on the code with the assistance of Axum and Askama.
 author: josh
-tags: [rust, htmx, html, tutorial]
+tags: [rust, htmx, html, guide]
 thumb: htmx-with-rust-thumb.png
 cover: htmx-with-rust-thumb.png
 date: '2023-11-01T14:30:00'

--- a/_blog/2023-11-15-ssg-in-rust.mdx
+++ b/_blog/2023-11-15-ssg-in-rust.mdx
@@ -9,9 +9,9 @@ date: '2023-11-15T14:30:00'
 ---
 We'll be making a website in the form of a Rust static site generator that we'll be able to add our own pages to. <strong>If you want to skip straight to the project, deploy your own instance and try it out, you can follow the instructions below: </strong>
 
-1) Run `cargo shuttle init --from joshua-mo-143/shuttle-ssg` and follow the prompt
+1) Run `shuttle init --from joshua-mo-143/shuttle-ssg` and follow the prompt
 2) `cd` to the folder
-3) Run `cargo shuttle deploy --allow-dirty` and your static site generator is live!
+3) Run `shuttle deploy --allow-dirty` and your static site generator is live!
 
 Don't forget to make sure that `cargo-shuttle` is installed and that you're logged in! You can also visit the repo [here.](https://www.github.com/joshua-mo-143/shuttle-ssg)
 
@@ -20,7 +20,7 @@ Don't forget to make sure that `cargo-shuttle` is installed and that you're logg
 Rust has always been seen from the outside as a language that takes quite a long time to write something in. While that might be true for more things involving more advanced type machinery (implementing your own job queues, implementing async traits manually, lifetimes), for a lot of things that don't require things that amount to mental space rocketry you can knock out a project surprisingly quickly. I want to challenge the assumption that Rust is a slow language to program in by writing a usable, extendable web service in an hour that also provides immediate value to anyone who would also like to use it.
 
 ## 59:59 - Getting Started
-It's time to lock in. I went on Youtube and put on a breakcore playlist, then used `cargo shuttle init --template axum` to quickly spin up what I wanted. I used the project name `ssg` and put it in my projects folder, then got to work. What helps me move quickly is that with Shuttle I don't need a Dockerfile; I just use the runtime, provision the things I need and I'm ready to get cracking.
+It's time to lock in. I went on Youtube and put on a breakcore playlist, then used `shuttle init --template axum` to quickly spin up what I wanted. I used the project name `ssg` and put it in my projects folder, then got to work. What helps me move quickly is that with Shuttle I don't need a Dockerfile; I just use the runtime, provision the things I need and I'm ready to get cracking.
 
 To finish my preparations, I created a `Shuttle.toml` file and added the following:
 ```toml
@@ -59,7 +59,7 @@ I made the handler generic by using the Path extractor, then quickly made the `t
 ## Hello world!
 ```
 
-I then used `cargo clippy` to make sure it all works. There's no errors. After that I used `cargo shuttle run` to get it working and then made the mistake of going to the base route at `/` instead of at `/hello_world` where the web service could read the Markdown file. Never mind! I'll fix that later - it looks like going to `/hello_world` works. Unfortunately, this part took the better part of 10 minutes due to waiting for Rust to compile; granted however, I'm on a laptop. We're not exactly expecting NASA-level performance out of this one.
+I then used `cargo clippy` to make sure it all works. There's no errors. After that I used `shuttle run` to get it working and then made the mistake of going to the base route at `/` instead of at `/hello_world` where the web service could read the Markdown file. Never mind! I'll fix that later - it looks like going to `/hello_world` works. Unfortunately, this part took the better part of 10 minutes due to waiting for Rust to compile; granted however, I'm on a laptop. We're not exactly expecting NASA-level performance out of this one.
 
 ## 47:12 - Adding CSS styling
 Now that we've got basic Rust markdown parsing functionality, we can move to the next part: styling our pages. I didn't want to spend a lot of time on this - if you're not careful, styling can eat up quite a lot of your time! I primarily wanted to just make sure the page didn't look horrible, so I added a small amount of CSS to center-align the text:
@@ -96,7 +96,7 @@ Then I added it to the HTML output before pushing the HTML to the empty string b
 html_output.push_str(r#"<link rel="stylesheet" type="text/css" href="/styles.css">"#);
 ```
 
-After starting up local development using `cargo shuttle run` and quickly checking the `/hello_world` route, I could see that the text was in fact now centre-aligned on the page. Great. Time to move onto the next part. With Shuttle's easy-to-use local development environment, you can also specify a port with the `-p` flag or test on a local network using `--external` to expose your web app to the local network.
+After starting up local development using `shuttle run` and quickly checking the `/hello_world` route, I could see that the text was in fact now centre-aligned on the page. Great. Time to move onto the next part. With Shuttle's easy-to-use local development environment, you can also specify a port with the `-p` flag or test on a local network using `--external` to expose your web app to the local network.
 
 ## 36:28 - Adding OpenGraph tags
 Now it's time to add [OpenGraph](https://ogp.me/) tags so I can get better SEO using the static site generator! This was a part I struggled with quite a lot. I remember when I last logged into Bearblog for my own blog articles that there was a bit at the top indented by three dashes where you could just add properties to an article and it would add the properties in the fenced off text block to [OpenGraph](https://ogp.me) meta tags, but I didn't know what it was called. I did some extensive Googling, and realised it was called "frontmatter" - as in the first bit of a book. That makes sense.
@@ -384,7 +384,7 @@ html_output.push_str(format!("<meta property=\"og:url\" content=\"{domain}\"/>);
 ## 00:40 - Finishing Up
 At this point, I'm basically done and there isn't much time left so I gave the app a quick `cargo clippy && cargo fmt`. I took a sip of my tea and realised it had gone cold. So much for being able to develop things quickly, I guess.
 
-I hammered out `cargo shuttle deploy --allow-dirty` to deploy my program from a dirty Git branch straight to the Shuttle servers. It started compiling and I leaned back and breathed a sigh of relief.
+I hammered out `shuttle deploy --allow-dirty` to deploy my program from a dirty Git branch straight to the Shuttle servers. It started compiling and I leaned back and breathed a sigh of relief.
 
 ## 00:00 - Retrospective
 So, I'd finally done it! I wrote a fully working Rust SSG in an hour. It wasn't quite the behemoth I thought it would be to get working, and for my personal blog it would *actually* be something I'd consider using. However, although we accomplished quite a bit in the alloted time, we could have extended it by doing things that wouldn't have taken too much more time than we have spent (although perhaps adding all of them would maybe double the time!) that could have provided some value:

--- a/_blog/2023-12-06-using-axum-rust.mdx
+++ b/_blog/2023-12-06-using-axum-rust.mdx
@@ -1,14 +1,14 @@
 ---
 title: "Getting Started with Axum - Rust's Most Popular Web Framework"
-description: This guide is a deep-dive on Axum, a Rust web backend framework. We look at using Axum to write a competent web service with middleware, routing, static files and more. 
+description: This guide is a deep-dive on Axum, a Rust web backend framework. We look at using Axum to write a competent web service with middleware, routing, static files and more.
 author: josh
 tags: [rust, axum, tutorial, guide]
-thumb: axum-thumb.png 
-cover: axum-thumb.png 
+thumb: axum-thumb.png
+cover: axum-thumb.png
 date: '2023-12-06T14:30:00'
 ---
 
-With so many backend web frameworks in the Rust web ecosystem, it's difficult to know what to choose. Although much further in the past you might have seen Rocket shoot to the top of the leadeboard for popularity, nowadays it's typically Axum and Actix Web battling it out with Axum slowly coming on top. In this article, we are going to do a deep dive into Axum, a web framework for making Rust REST APIs backed by the Tokio team that's simple to use and has hyper-compatibility with Tower, a robust library of reusable, modular components for building network applications. 
+With so many backend web frameworks in the Rust web ecosystem, it's difficult to know what to choose. Although much further in the past you might have seen Rocket shoot to the top of the leadeboard for popularity, nowadays it's typically Axum and Actix Web battling it out with Axum slowly coming on top. In this article, we are going to do a deep dive into Axum, a web framework for making Rust REST APIs backed by the Tokio team that's simple to use and has hyper-compatibility with Tower, a robust library of reusable, modular components for building network applications.
 
 In this article we'll take a comprehensive look at how to use Axum to write a web service. This will also include the [0.7 changes.](https://github.com/tokio-rs/axum/releases/tag/axum-v0.7.0)
 
@@ -86,7 +86,7 @@ async fn my_function() -> Result<ApiResponse, ApiError> {
 }
 ```
 
-This allows us to differentiate between errors and successful requests when writing our Axum routing. 
+This allows us to differentiate between errors and successful requests when writing our Axum routing.
 
 ## Adding a Database in Axum
 Normally when setting up a database, you might need to set up your database connection:
@@ -106,9 +106,9 @@ async fn main() {
         .connect(<db-connection-string-here>).await;
 
     let state = AppState { pool };
-        
+
     let router = Router::new().route("/", get(hello_world)).with_state(state);
-    
+
     //... rest of your code
 }
 ```
@@ -121,7 +121,7 @@ async fn axum(
     #[shuttle_shared_db::Postgres] pool: PgPool,
 ) -> shuttle_axum::ShuttleAxum {
     let state = AppState { pool };
-    
+
     // .. the rest of your code
 }
 ```
@@ -142,7 +142,7 @@ async fn axum(
     #[shuttle_shared_db::Postgres] pool: PgPool,
 ) -> shuttle_axum::ShuttleAxum {
     let state = AppState { pool };
-    
+
     // .. the rest of your code
 }
 
@@ -176,7 +176,7 @@ use std::sync::Arc;
 
 let state = Arc::new(AppState { db });
 ```
-When you add the state to your application now, you would need to make sure to refer to the State extractor type as `State<Arc<AppState>>` rather than `State<AppState>`. 
+When you add the state to your application now, you would need to make sure to refer to the State extractor type as `State<Arc<AppState>>` rather than `State<AppState>`.
 
 From personal observation, it does not seem to be clear which method is better. It is likely that `Arcs` are going to perform better in a micro-benchmark but whether this leads to real-world improvements will likely depend on your use case.
 
@@ -231,11 +231,11 @@ async fn my_function(
     Json(json): Json<Submission>
 ) -> Result<ApiResponse, ApiError> {
     println!("{}", json.message);
-    
+
     // ... your code
 }
 ```
-Note that any fields that are not in the struct **will be ignored** - depending on your use case, this can be a good thing; for example, if you're receiving a webhook but only want to look at certain fields from the webhook request. 
+Note that any fields that are not in the struct **will be ignored** - depending on your use case, this can be a good thing; for example, if you're receiving a webhook but only want to look at certain fields from the webhook request.
 
 Forms and URL query parameters can be handled the same way by adding the appropriate type to your handler function - so for example, a form extractor might look like this:
 ```rust
@@ -243,11 +243,11 @@ async fn my_function(
     Form(form): Form<Submission>
 ) -> Result<ApiResponse, ApiError> {
     println!("{}", json.message);
-    
+
     // ... your code
 }
 ```
-On the HTML side when you're sending a HTTP request to your API, you will also of course want to make sure you are sending the correct content type. 
+On the HTML side when you're sending a HTTP request to your API, you will also of course want to make sure you are sending the correct content type.
 
 Headers can also be handled the same way except that headers don't consume the request body - which means you can use as many as you want! We can use the `TypedHeader` type to do this. For Axum 0.6 you will need to enable the `headers` feature, but in 0.7 this has been moved to the `axum-extra` crate which you will need to add the `typed-header` feature, like so:
 ```bash
@@ -264,7 +264,7 @@ async fn my_function(
     TypedHeader(origin): TypedHeader<Origin>
 ) -> Result<ApiResponse, ApiError> {
     println!("{}", origin.hostname);
-    
+
     // ... your code
 }
 ```
@@ -287,7 +287,7 @@ async fn handler(JsonOrForm(payload): JsonOrForm<Payload>) {
 
 struct JsonOrForm<T>(T);
 ```
-Now we can implement `FromRequest<S, B>` for our `JsonOrForm` struct! 
+Now we can implement `FromRequest<S, B>` for our `JsonOrForm` struct!
 ```rust
 #[async_trait]
 impl<S, B, T> FromRequest<S, B> for JsonOrForm<T>
@@ -418,7 +418,7 @@ If you need to add app state to your middleware, you can add it to your handler 
 ```rust
 fn init_router() -> Router {
     let state = setup_state(); // app state initialisation goes here
-    
+
     Router::new()
         .route("/", get(hello_world))
         .layer(middleware::from_fn_with_state(state.clone(), check_hello_world))
@@ -460,11 +460,11 @@ fn init_router() -> Router {
 You can also use HTML templating with crates like [`askama`](https://github.com/djc/askama), [`tera`](https://github.com/Keats/tera) and [`maud`](https://maud.lambda.xyz/)! This can be combined with the power of lightweight JavaScript libraries like [`htmx`](https://htmx.org) to speed up time to production. You can read more about this on our other article about using HTMX with Rust which you can find [here.](https://www.shuttle.dev/blog/2023/10/25/htmx-with-rust). We also collaborated with [Stefan Baumgartner](https://fettblog.eu) on an article for [serving HTML with Askama!](https://www.shuttle.dev/launchpad/issues/2023-10-17-issue-10-Serving-HTML)
 
 ## How to Deploy Axum
-Deployment with Rust backend programs in general can be less than ideal due to having to use Dockerfiles, although if you are experienced with Docker already this may not be such an issue for you - particularly if you are using `cargo-chef`. However, if you're using Shuttle you can just use `cargo shuttle deploy` and you're done already. No setup is required.
+Deployment with Rust backend programs in general can be less than ideal due to having to use Dockerfiles, although if you are experienced with Docker already this may not be such an issue for you - particularly if you are using `cargo-chef`. However, if you're using Shuttle you can just use `shuttle deploy` and you're done already. No setup is required.
 
 ## Finishing Up
 Thanks for reading! Axum is a great framework that has a strong team backing and is highly compatible with the Rust web ecosystem, and we believe now is a better time than ever to get started writing a REST API in Rust.
- 
+
 Interested in more?
 - Check out how you can implement authentication in Axum [here!](https://www.shuttle.dev/blog/2022/08/11/authentication-tutorial)
 - Have a look at how you can get started with logging for your web application [here.](https://www.shuttle.dev/blog/2023/09/20/logging-in-rust)

--- a/_blog/2023-12-13-using-rocket-rust.mdx
+++ b/_blog/2023-12-13-using-rocket-rust.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Getting Started with Rocket in Rust" 
+title: "Getting Started with Rocket in Rust"
 description: This article talks about how you can use Rocket to write a web application, covering routing, middleware, static files and databases.
 author: josh
 tags: [rust, rocket, tutorial, guide]
-thumb: rocket-rust-thumb.png 
+thumb: rocket-rust-thumb.png
 cover: rocket-rust-thumb.png
 date: '2023-12-13T14:30:00'
 ---
@@ -16,7 +16,7 @@ The main things you need to know:
 - `rocket_contrib` is deprecated - you need to enable features in Rocket itself (and use `rocket_dyn_templates` and `rocket_sync_db_pools`/`rocket_db_pools` as required)
 - Rocket is now primarily async and now re-exports `tokio` if you need anything Tokio-related
 - You need to use `#[rocket::async_trait]` for trait implementations now
-- Query parameters now use `FromForm`! 
+- Query parameters now use `FromForm`!
 - Server Sent Events and Websockets are now officially supported.
 
 The above listed points are but a highlight - there have been an extremely significant number of changes in the upgrade to Rocket 0.5. If you're looking to migrate, you can check out the docs [here.](https://rocket.rs/v0.5/guide/upgrading/)
@@ -42,7 +42,7 @@ We can attach a route to a router like this by using `rocket::build()` and then 
 ```rust
 let rocket = rocket::build().mount("/hello", routes![index]);
 ```
-This essentially means that when you load up your web service and go to the `/hello` route in the browser, it should also print "Hello world!" - note that it is **based on the route where it is mounted**. You can also add additional routes to the `routes!` macro - so if you have multiple sub-routes that you want to host under main route, you can do that. 
+This essentially means that when you load up your web service and go to the `/hello` route in the browser, it should also print "Hello world!" - note that it is **based on the route where it is mounted**. You can also add additional routes to the `routes!` macro - so if you have multiple sub-routes that you want to host under main route, you can do that.
 
 Deserializing JSON in Rocket, similarly to other web frameworks in Rust, involves using `serde` to make the data compatible with (de)serialization. You can add the serde functionality to your web service by adding it as a crate with the `derive` feature:
 ```bash
@@ -65,7 +65,7 @@ fn new(task: Json<Task<'_>>) { /* .. */ }
 ```
 You can find out more about using JSON data with Rocket [here.](https://rocket.rs/v0.5/guide/requests/#json)
 
-Are you using forms? You can also use those! Rocket has a [huge](https://rocket.rs/v0.5/guide/requests/#forms) section detailing everything you can do with forms, but we'll cover the highlights and essentials you need to become good at using forms in Rocket. 
+Are you using forms? You can also use those! Rocket has a [huge](https://rocket.rs/v0.5/guide/requests/#forms) section detailing everything you can do with forms, but we'll cover the highlights and essentials you need to become good at using forms in Rocket.
 
 You can get started with forms by using the `FromForm` derive macro, then adding it as an argument to a handler function:
 ```rust
@@ -94,7 +94,7 @@ You can also just add `Strict` to the parameters when writing your handler funct
 #[post("/todo", data = "<task>")]
 fn new(task: Form<Strict<Task<'_>>>) { /* .. */ }
 ```
-Rocket is miles ahead of other web frameworks when it comes to forms, particularly because multipart forms are handled similarly to regular forms and do not require any extra work. For comparison: in Axum for example, you need to enable the `multipart` feature and iterate through every single multipart field manually in the function handler, which can be quite ugly. 
+Rocket is miles ahead of other web frameworks when it comes to forms, particularly because multipart forms are handled similarly to regular forms and do not require any extra work. For comparison: in Axum for example, you need to enable the `multipart` feature and iterate through every single multipart field manually in the function handler, which can be quite ugly.
 
 You can also nest your form structs:
 ```rust
@@ -173,7 +173,7 @@ It should be noted that if you need authentication or other processes that only 
 Instead of implementing a trait for your errors, error handling is done a bit differently in Rocket. Instead of traits, you handle errors by using an error handler which is called a "catcher" - the equivalent of this in other frameworks like Axum might be a fallback service, or a route that the HTTP client gets automatically redirected to if it can't find anything or a user isn't authenticated (for example). You can use a handler function for creating a catcher, like so:
 ```rust
 #[catch(default)]
-fn default_catcher(status: Status, request: &Request) -> String { 
+fn default_catcher(status: Status, request: &Request) -> String {
     format!("ERROR: {} - {}", status.code, status.reason)
 }
 
@@ -189,7 +189,7 @@ fn foo_not_found() -> &'static str {
     "Foo 404"
 }
 ```
-Although it is quite easy to use macros for error handling functions in Rocket, you need to also make sure that you attach the handlers to your router! 
+Although it is quite easy to use macros for error handling functions in Rocket, you need to also make sure that you attach the handlers to your router!
 
 ## Adding a Database
 Normally when setting up a database in Rust, you might need to set up your own database connection. To get started with doing this in Rocket, you will need to add the `rocket-db-pools` crate with the `sqlx_postgres` feature:
@@ -227,7 +227,7 @@ async fn rocket(
     #[shuttle_shared_db::Postgres] pool: PgPool,
 ) -> shuttle_rocket::ShuttleRocket {
     let state = AppState { pool };
-    
+
     pool.execute(include_str!("../schema.sql"))
         .await
         .map_err(CustomError::new)?;
@@ -243,7 +243,7 @@ Locally the database is provisioned through Docker, but in deployment there is a
 
 
 ## App State
-Rocket, like other Rust web frameworks, allows you to share variables between routes in your web application by holding it in a state struct in memory. Then in your handler functions, you can call the data as required (for example, if you need a database pool, you can attach it to your state struct and then use it as below). 
+Rocket, like other Rust web frameworks, allows you to share variables between routes in your web application by holding it in a state struct in memory. Then in your handler functions, you can call the data as required (for example, if you need a database pool, you can attach it to your state struct and then use it as below).
 
 To get started, you can add application state like so:
 ```rust
@@ -255,12 +255,12 @@ struct AppState {
 
 async fn main() {
     let db = connect_to_db();
-    
+
     rocket::build()
         .manage(AppState { db }});
 }
 ```
-As you can see, unlike in Axum where the application state struct requires it to implement Clone, there are no trait bounds besides `Send + Sync`. 
+As you can see, unlike in Axum where the application state struct requires it to implement Clone, there are no trait bounds besides `Send + Sync`.
 
 Now you can use whatever's in your state struct like this:
 ```rust
@@ -278,7 +278,7 @@ fn get_data(state: &State<AppState>, id: i32) -> Vec<Thing> {
         .fetch_all(&state.db)
         .await
         .unwrap();
-        
+
     result
 }
 ```
@@ -425,7 +425,7 @@ The `rocket_dyn_template` library supports both Handlebars templating as well as
 If you're looking to try out Tera, you can find the docs [here](https://keats.github.io/tera/docs/) - meanwhile if you're interested in Handlebars, you can get started [here.](https://handlebarsjs.com/guide/)
 
 ## Configuration
-Unlike most other frameworks, Rocket comes with config files based on the [figment crate](https://docs.rs/figment/0.10.12/figment/) that allow you to set the config from a few files rather than having the configuration spread out over your application, where you're able to split your configuration into development, staging and production. From this file you can set things like address and port, keep_alive timer, request timeouts, secret keys as well as request body limiting! 
+Unlike most other frameworks, Rocket comes with config files based on the [figment crate](https://docs.rs/figment/0.10.12/figment/) that allow you to set the config from a few files rather than having the configuration spread out over your application, where you're able to split your configuration into development, staging and production. From this file you can set things like address and port, keep_alive timer, request timeouts, secret keys as well as request body limiting!
 
 An example of this file would be like this:
 ```toml
@@ -457,10 +457,10 @@ secret_key = "hPrYyЭRiMyµ5sBB1π+CMæ1køFsåqKvBiQJxBVHQk="
 ```
 
 ## Deployment
-Deployment with Rust backend programs in general can be less than ideal due to having to use Dockerfiles, although if you are experienced with Docker already this may not be such an issue for you - particularly if you are using cargo-chef. However, if you're using Shuttle you can just use `cargo shuttle deploy` and you're done already. No setup is required.
+Deployment with Rust backend programs in general can be less than ideal due to having to use Dockerfiles, although if you are experienced with Docker already this may not be such an issue for you - particularly if you are using cargo-chef. However, if you're using Shuttle you can just use `shuttle deploy` and you're done already. No setup is required.
 
 ## Finishing Up
-Thanks for reading! Although Rocket has previously fell out of favor among people who wanted to use cutting-edge Rust frameworks, the 0.5 upgrade brings a lot of new changes - hopefully this  has helped you to create a competent Rust web API using Rocket! 
+Thanks for reading! Although Rocket has previously fell out of favor among people who wanted to use cutting-edge Rust frameworks, the 0.5 upgrade brings a lot of new changes - hopefully this  has helped you to create a competent Rust web API using Rocket!
 
 Interested in more?
 - We have a guide to getting started with Axum if you'd like to compare the two frameworks [here.](https://www.shuttle.dev/blog/2023/12/06/using-axum-rust)

--- a/_blog/2023-12-15-using-actix-rust.mdx
+++ b/_blog/2023-12-15-using-actix-rust.mdx
@@ -482,7 +482,7 @@ Interested in learning more about Askama? We have a Shuttle Launchpad newsletter
 
 ## Deploying
 
-Deployment with Rust backend programs, in general, can be less than ideal due to having to use Dockerfiles, although if you are experienced with Docker already this may not be such an issue for you - particularly if you are using `cargo-chef`. However, if you're using Shuttle you can just use `cargo shuttle deploy` and you're done already. No setup is required.
+Deployment with Rust backend programs, in general, can be less than ideal due to having to use Dockerfiles, although if you are experienced with Docker already this may not be such an issue for you - particularly if you are using `cargo-chef`. However, if you're using Shuttle you can just use `shuttle deploy` and you're done already. No setup is required.
 
 ## Finishing Up
 

--- a/_blog/2023-12-20-loco-rust-rails.mdx
+++ b/_blog/2023-12-20-loco-rust-rails.mdx
@@ -3,11 +3,11 @@ title: "Introducing Loco: The Rails of Rust"
 description: This article talks about how you can deploy Loco.rs to Shuttle, as well as an in-depth review of what the framework offers.
 author: josh
 tags: [rust, loco, tutorial, guide]
-thumb: loco-rust-thumb.png 
+thumb: loco-rust-thumb.png
 cover: loco-rust-thumb.png
 date: '2023-12-20T14:30:00'
 ---
-Although Ruby on Rails is not as popular as it used to be, in its prime, it was a force to be reckoned with. Many successful businesses were built from it - Airbnb and Shopify being two of many big names coming out of this, although more recently Shopify has started experimenting with other languages and late last year announced that they would be [officially supporting Rust.](https://shopify.engineering/shopify-rust-systems-programming) 
+Although Ruby on Rails is not as popular as it used to be, in its prime, it was a force to be reckoned with. Many successful businesses were built from it - Airbnb and Shopify being two of many big names coming out of this, although more recently Shopify has started experimenting with other languages and late last year announced that they would be [officially supporting Rust.](https://shopify.engineering/shopify-rust-systems-programming)
 
 This has led to many frameworks attempting to emulate the Rails philosophy - Loco.rs being no different. In this case, however, it aims to solve a long-standing issue within the Rust web backend framework in terms of there being no truly batteries-included Rust framework. Let's talk about it.
 
@@ -16,7 +16,7 @@ Ruby on Rails was popular because it is a framework that does all the heavy lift
 
 It achieves these things by gating everything behind a command-line interface: you use the command line to start the web service itself, you use it for migrations, and job processing as well as creating new controllers, models, and more. For example, you can generate a database model by using `rails generate model test` which will generate a model. You can then create a route controller by using `rails generate controller test`, which will generate a controller called `TestController` - you can do the same for migrations by using `rake generate migration`.
 
-This is somewhat at odds when it comes to Rust which is why Loco.rs is interesting: Rust is a language that allows you to get into the meat of the matter when it comes to low-level details, which means that it tends to attract programmers who don't mind doing the extra work because they would rather things be either implemented to their standard or because they want to understand how everything works so that when something breaks, they know how to fix it. In addition, Loco is not itself a standalone framework - currently it uses `axum` under the hood, alongside `sidekiq-rs` for job processing and `sea-orm` for migrations. 
+This is somewhat at odds when it comes to Rust which is why Loco.rs is interesting: Rust is a language that allows you to get into the meat of the matter when it comes to low-level details, which means that it tends to attract programmers who don't mind doing the extra work because they would rather things be either implemented to their standard or because they want to understand how everything works so that when something breaks, they know how to fix it. In addition, Loco is not itself a standalone framework - currently it uses `axum` under the hood, alongside `sidekiq-rs` for job processing and `sea-orm` for migrations.
 
 ## Getting Started with Loco
 To get started with the Rust Loco crate, you need to use their CLI which you can install by using the following:
@@ -27,7 +27,7 @@ cargo install loco-cli
 You can start a new project by using `loco new` - it'll ask you what the name of your app is and then what kind of app you want. For this article, we'll be talking about the full Rust SaaS starter application.
 
 ## Routing in Loco
-Although Loco uses `axum` under the hood, it abstracts some things away into config files that you can find in the `config` folder. 
+Although Loco uses `axum` under the hood, it abstracts some things away into config files that you can find in the `config` folder.
 
 The Axum service that gets run by the application implements the `Hooks` trait from `loco_cli`, which requires several functions to use - going to `src/app.rs` shows that we have functions for registering routes, getting the app name, connecting workers and registering tasks, truncate tables and seed data into the database. We can also add extra functions to the router that get hooked into the CLI as well - `after_routes()` which is for adding things like middleware, and `before_run()` which allows you to carry out operations before your application itself starts. Note that any commands we use through the project CLI to generate things will automatically be appended to the `app.rs` file - no need to do it yourself!
 
@@ -54,7 +54,7 @@ pub fn routes() -> Routes {
 ```
 Now you can add any routes you want to this file and it will be put under this controller when it's added to the `routes()` function in the file. Route-wise, this means it'll be all under the same route. You can access the database connection from the provided `State` - unlike in Axum normally, you don't need to create this yourself.
 
-The great thing about Loco's routing is that everything you know from using Axum can be applied here - so if you know how to write your own extractors, write middleware, and other things this can all be used in Loco since it essentially builds on top of Axum. 
+The great thing about Loco's routing is that everything you know from using Axum can be applied here - so if you know how to write your own extractors, write middleware, and other things this can all be used in Loco since it essentially builds on top of Axum.
 
 Once you've finished adding all the controllers and routes you want, you can use `cargo loco routes` to display all of the routes your application currently has.
 
@@ -66,7 +66,7 @@ cargo loco generate model <name-of-model>
 This will then generate a model that you can use in your application. You can also initialise with extra fields to generate a full model:
 ```bash
 cargo loco generate model movies title:string rating:int
-``` 
+```
 
 Note that if you want to initialise with extra fields, you will want to check the [reference docs](https://loco.rs/docs/the-app/models/) so you can find what fields you need to use. Once you're done adding all the models you need to, you can simply run the following two commands to get back the migrations and entities required:
 ```bash
@@ -135,16 +135,16 @@ pub async fn update(
 ) -> Result<Json<Model>> {
     // use sea_orm to load an item based on the id
     let item = load_item(&ctx, id).await?;
-    
+
     // turn the item into an ActiveModel that we can then use
     let mut item = item.into_active_model();
-    
+
     // update the parameters of the current item with the new properties
     params.update(&mut item);
-    
+
     // feed the new item back into the database
     let item = item.update(&ctx.db).await?;
-    
+
     // return the updated item
     format::json(item)
 }
@@ -173,13 +173,13 @@ impl From<&ActiveModel> for ModelValidator {
 ## Job Processing in Loco
 Like with everything else in Loco, you can also generate workers and tasks via the CLI. Running `cargo loco generate task` or `cargo loco generate worker` will let you generate a task or a worker at will.
 
-Under the hood, Loco uses `sidekiq-rs` to do job processing - which is a Rust re-implementation of its Ruby counterpart, `sidekiq.rb`. Once the worker is generated, you want to go to the `workers` folder and check out the file you made - it will have a struct for the worker itself, a struct that holds the arguments that the worker will take, an implementation of the `AppWorker` trait for the worker and then an async trait implementation that lets the worker do something. 
+Under the hood, Loco uses `sidekiq-rs` to do job processing - which is a Rust re-implementation of its Ruby counterpart, `sidekiq.rb`. Once the worker is generated, you want to go to the `workers` folder and check out the file you made - it will have a struct for the worker itself, a struct that holds the arguments that the worker will take, an implementation of the `AppWorker` trait for the worker and then an async trait implementation that lets the worker do something.
 
 You can then run it like so:
 ```rust
 ReportWorkerWorker::perform
     (
-        &boot.app_context, 
+        &boot.app_context,
         ReportWorkerWorkerArgs {}
     )
 .await
@@ -197,12 +197,11 @@ This lets you choose between Docker and Shuttle. When choosing Docker it will ge
 ```bash
 // note that if you want to avoid using the --name flag
 // you should use the name key in Shuttle.toml
-cargo shuttle start --name <name-of-project>
-cargo shuttle deploy --name <name-of-project>
+shuttle deploy --name <name-of-project>
 ```
 
 ## Finishing Up
-Thanks for reading! Loco is a great framework that shows a lot of promise, and is growing very quickly. Building a Rest API in Rust has never been made easier! 
+Thanks for reading! Loco is a great framework that shows a lot of promise, and is growing very quickly. Building a Rest API in Rust has never been made easier!
 
 Interested in more?
 Check out the full tour of Loco [here.](https://loco.rs/docs/getting-started/tour/)

--- a/_blog/2023-12-28-using-loco-rust-rails.mdx
+++ b/_blog/2023-12-28-using-loco-rust-rails.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Getting Started with Loco in Rust: Part 1"
-description: This article goes into a deep dive on getting started with Loco in Rust and how you can utilise its capabilities to speed up your productivity. 
+description: This article goes into a deep dive on getting started with Loco in Rust and how you can utilise its capabilities to speed up your productivity.
 author: josh
 tags: [rust, loco, tutorial, guide]
-thumb: loco-rust-thumb.png 
+thumb: loco-rust-thumb.png
 cover: loco-rust-thumb.png
 date: '2023-12-28T14:30:00'
 ---
@@ -68,7 +68,7 @@ pub fn routes() -> Routes {
         .add("/echo", post(echo))
 ```
 
-Now we can get to work on the routes for this! 
+Now we can get to work on the routes for this!
 
 If you check the source code for what `AppContext` contains [here](https://github.com/loco-rs/loco/blob/68cb7598127893253478c4eddae0762e208aab6e/src/app.rs#L31), you should get this:
 
@@ -79,7 +79,7 @@ pub struct AppContext {
     /// The environment in which the application is running.
     pub environment: Environment,
     #[cfg(feature = "with-db")]
-    /// A database connection used by the application.    
+    /// A database connection used by the application.
     pub db: DatabaseConnection,
     /// An optional connection pool for Redis, for worker tasks
     pub redis: Option<Pool<RedisConnectionManager>>,
@@ -104,7 +104,7 @@ pub async fn hello(State(ctx): State<AppContext>) -> Result<Json<Vec<ItemModel>>
 }
 ```
 
-Note that we need to import our models and entities from the `entities` folder. 
+Note that we need to import our models and entities from the `entities` folder.
 
 We can extend this to create a full CRUD controller:
 
@@ -150,7 +150,7 @@ pub async fn update_item_quantity(
 }
 
 pub async fn delete_item(
-	Path<id>: Path<i32>, 
+	Path<id>: Path<i32>,
 	State(ctx): State<AppContext>
 ) -> Result<String> {
     let item: Option<item::Model> = Item::find_by_id(id).one(db).await?;
@@ -215,7 +215,7 @@ You can also write an `impl` for the `Model` itself to extend its behavior! Note
 
 ```rust
 // src/models/users.rs
-pub async fn find_by_email(db: &DatabaseConnection, email: &str) -> ModelResult<Self> 
+pub async fn find_by_email(db: &DatabaseConnection, email: &str) -> ModelResult<Self>
     let user = users::Entity::find()
         .filter(users::Column::Email.eq(email))
         .one(db)
@@ -311,10 +311,9 @@ assets = ["frontend/dist/*"]
 
 Then you can run the following to deploy your application (don't forget to install `cargo-shuttle`):
 ```bash
-cargo shuttle project start
-cargo shuttle deploy 
+shuttle deploy
 ```
-We are planning to release a native database integration with Loco! Stay tuned for part 2 where we will go into further detail about how you can build out your dream web application. 
+We are planning to release a native database integration with Loco! Stay tuned for part 2 where we will go into further detail about how you can build out your dream web application.
 
 ## Finishing Up
 Thanks for reading! We hope this Rust Loco guide has helped you. If you're looking to get started with Rust web development, now is a better time than ever to do so.

--- a/_blog/2024-01-11-bypassing-aws-complexity.mdx
+++ b/_blog/2024-01-11-bypassing-aws-complexity.mdx
@@ -1,8 +1,8 @@
 ---
 title: "How We're Bypassing AWS Complexity"
 description: This article talks about how Shuttle bypasses AWS complexity.
-thumb: bypass-aws-complexity-thumb.png 
-cover: bypass-aws-complexity-thumb.png 
+thumb: bypass-aws-complexity-thumb.png
+cover: bypass-aws-complexity-thumb.png
 date: '2024-01-11T14:30:00'
 ---
 ## Our mission..
@@ -25,7 +25,7 @@ Our aim is to enhance the Rust development experience. We've built our open-sour
 
 ### 1. Providing tooling that simplifies deployments
 
-We provide tooling that simplifies deployment by allowing users to add our Shuttle runtime macro to their applications. This means all you need to do is run `cargo shuttle deploy` and your web service gets sent to the Shuttle servers, containerized, and started. No further steps are required!
+We provide tooling that simplifies deployment by allowing users to add our Shuttle runtime macro to their applications. This means all you need to do is run `shuttle deploy` and your web service gets sent to the Shuttle servers, containerized, and started. No further steps are required!
 
 Check the video below for a short example:
 

--- a/_blog/2024-01-24-writing-cronjobs-rust.mdx
+++ b/_blog/2024-01-24-writing-cronjobs-rust.mdx
@@ -3,12 +3,12 @@ title: "Writing Cronjobs in Rust"
 description: This article talks about how you can write cron jobs as a web service on Shuttle using the apalis cron job framework.
 author: josh
 tags: [cronjob, rust, tutorial, guide]
-thumb: cronjobs-rust-thumb.png 
+thumb: cronjobs-rust-thumb.png
 cover: cronjobs-rust-thumb.png
 date: '2024-01-23T14:30:00'
 ---
 
-In this article we’re going to talk about how you can write your own cron jobs as a web service using Shuttle! 
+In this article we’re going to talk about how you can write your own cron jobs as a web service using Shuttle!
 
 Cron jobs (or “scheduled tasks”) are useful for many things. They allow you to automatically do things like:
 
@@ -18,9 +18,9 @@ Cron jobs (or “scheduled tasks”) are useful for many things. They allow you 
 
 If you’re interested in the final code and want to deploy quickly, you can find the repo [here.](https://github.com/shuttle-hq/shuttle-examples/tree/main/shuttle-cron) You can deploy it with two simple steps:
 
-1) Run `cargo shuttle init --from shuttle-hq/shuttle-examples --subfolder shuttle-cron` and follow the prompt (requires `cargo-shuttle` installed)
+1) Run `shuttle init --from shuttle-hq/shuttle-examples --subfolder shuttle-cron` and follow the prompt (requires `cargo-shuttle` installed)
 
-2) Run `cargo shuttle deploy`. That’s it!
+2) Run `shuttle deploy`. That’s it!
 
 ## Getting Started
 
@@ -33,10 +33,10 @@ cargo install cargo-shuttle
 To get started, you’ll want to initialise a project with `cargo-shuttle`:
 
 ```bash
-cargo shuttle init 
+shuttle init
 ```
 
-You’ll want to make sure to follow the prompt and choose `None` when the framework options come up. This will spawn a custom service that you can use with Shuttle. For this article, we will be using the project name `shuttle-example-cron`. 
+You’ll want to make sure to follow the prompt and choose `None` when the framework options come up. This will spawn a custom service that you can use with Shuttle. For this article, we will be using the project name `shuttle-example-cron`.
 
 Once done, we’ll want to install the following dependencies:
 
@@ -55,7 +55,7 @@ cargo add chrono -F serde,clock
 cargo add serde -F derive
 cargo add shuttle-shared-db -F postgres
 cargo add sqlx -F runtime-tokio-native-tls,postgres
-cargo add tower 
+cargo add tower
 ```
 
 Now that everything is installed, it’s time to get coding!
@@ -132,8 +132,8 @@ However, if you want to add extra variables (for example, a database connection 
 
 ```rust
 #[derive(Clone)]
-struct CronjobData { 
-    message: String 
+struct CronjobData {
+    message: String
 }
 
 impl CronjobData {
@@ -166,7 +166,7 @@ To start with, we need to set up the `PostgresStorage` type so that we can use P
 #[shuttle_runtime::async_trait]
 impl shuttle_runtime::Service for MyService {
     async fn bind(
-        self, 
+        self,
         _addr: std::net::SocketAddr
     ) -> Result<(), shuttle_runtime::Error> {
         // set up Postgres-backed storage
@@ -196,7 +196,7 @@ let cron_service_ext = CronjobData {
 let service = ServiceBuilder::new()
     .layer(RetryLayer::new(DefaultRetryPolicy))
     .layer(Extension(cron_service_ext))
-    .service(job_fn(say_hello_world)); 
+    .service(job_fn(say_hello_world));
 ```
 
 Now that we’ve built the service, we need to build the worker and then finally create an `apalis::Monitor` process that will carry the work out:
@@ -231,39 +231,39 @@ Here is the full code for our main application:
 #[shuttle_runtime::async_trait]
 impl shuttle_runtime::Service for MyService {
     async fn bind(
-        self, 
+        self,
         _addr: std::net::SocketAddr
     ) -> Result<(), shuttle_runtime::Error> {
         let storage = PostgresStorage::new(self.db.clone());
         // set up storage
         storage.setup().await.expect("Unable to run migrations :(");
-    
-        let cron_service_ext = CronjobData { 
-            message: "Hello world".to_string() 
+
+        let cron_service_ext = CronjobData {
+            message: "Hello world".to_string()
         };
-    
+
         // create a servicebuilder for the cronjob
         let service = ServiceBuilder::new()
             .layer(RetryLayer::new(DefaultRetryPolicy))
             .layer(Extension(cron_service_ext))
             .service(job_fn(say_hello_world));
- 
+
         let schedule = Schedule::from_str("* * * * * *")
             .expect("Couldn't start the scheduler!");
-    
+
         // create a worker that uses the service created from the cronjob
         let worker = WorkerBuilder::new("morning-cereal")
             .with_storage(storage.clone())
             .stream(CronStream::new(schedule).timer(TokioTimer).to_stream())
             .build(service);
-    
+
         // start your worker up
         Monitor::new()
             .register(worker)
             .run()
             .await
             .expect("Unable to start worker");
-    
+
             Ok(())
     }
 }
@@ -271,7 +271,7 @@ impl shuttle_runtime::Service for MyService {
 
 ## Deploying
 
-Now that we’ve written everything, all you need to do is `cargo shuttle deploy` (with the `--allow-dirty` flag if working on a dirty Git branch). When the deployment is finished, you’ll get the deployment information as well as the deployment database URL string.
+Now that we’ve written everything, all you need to do is `shuttle deploy` (with the `--allow-dirty` flag if working on a dirty Git branch). When the deployment is finished, you’ll get the deployment information as well as the deployment database URL string.
 
 ## Extending
 

--- a/_blog/2024-01-31-write-a-rest-api-rust.mdx
+++ b/_blog/2024-01-31-write-a-rest-api-rust.mdx
@@ -1,10 +1,10 @@
 ---
 title: Writing a REST API in Rust
-description: This article talks about how you can write a Rust REST API using Axum, SQLx and Postgres. 
+description: This article talks about how you can write a Rust REST API using Axum, SQLx and Postgres.
 author: josh
 tags: [rust, axum, guide]
-thumb: write-rest-api-rust-thumb.png 
-cover: write-rest-api-rust-thumb.png 
+thumb: write-rest-api-rust-thumb.png
+cover: write-rest-api-rust-thumb.png
 date: '2024-01-31T14:30:00'
 ---
 
@@ -23,9 +23,9 @@ We'll be initialising our project with `cargo-shuttle`, Shuttle's CLI. You can i
 cargo install cargo-shuttle
 ```
 
-Installation via `cargo-binstall` is also supported, along with our other install scripts which you can find [here.](https://docs.shuttle.rs/getting-started/installation)  
+Installation via `cargo-binstall` is also supported, along with our other install scripts which you can find [here.](https://docs.shuttle.rs/getting-started/installation)
 
-First of all we’ll want to initialise our project with `cargo shuttle init` (required `cargo-shuttle` to be installed). For the project name we’ll be using `shuttle-example-axum`. 
+First of all we’ll want to initialise our project with `shuttle init` (required `cargo-shuttle` to be installed). For the project name we’ll be using `shuttle-example-axum`.
 
 Then we’ll want to set up our dependencies with the following shell snippet:
 
@@ -48,8 +48,8 @@ async fn main(
 }
 ```
 During deployment, Shuttle will automatically provision a database to our project without any input required from us! Locally, it will use Docker to spin up the Postgres container - you can also use Podman and similar programs that allow Docker usage through them. You can find the installation for Docker [here.](https://www.docker.com/)
- 
-Interested in just getting the connection string? You can disable the `sqlx` feature of `shuttle-shared-db` and instead change the type to `String`, then connect to your PgPool. You can find more information about connecting to a PgPool [here.](https://docs.rs/sqlx/latest/sqlx/type.PgPool.html#method.connect) 
+
+Interested in just getting the connection string? You can disable the `sqlx` feature of `shuttle-shared-db` and instead change the type to `String`, then connect to your PgPool. You can find more information about connecting to a PgPool [here.](https://docs.rs/sqlx/latest/sqlx/type.PgPool.html#method.connect)
 
 Since we’re using only a single migrations file, we can use `include_str!()` to include the whole file’s text content as a string. We can then execute the query with the database pool.
 
@@ -100,7 +100,7 @@ let router = Router::new().route("/", get(hello_world)).with_state(state);
 
 ### Writing routes
 
-When writing your routes, Axum will accept anything that implements the `IntoResponse` trait (which means the type can be turned into a HTTP response). Many primitives already have `IntoResponse` implemented so you can return things like `i32` or a `String` (or a `'static &str`) without being required to implement the trait. 
+When writing your routes, Axum will accept anything that implements the `IntoResponse` trait (which means the type can be turned into a HTTP response). Many primitives already have `IntoResponse` implemented so you can return things like `i32` or a `String` (or a `'static &str`) without being required to implement the trait.
 
 By using Axum’s `extractors`, we can extract information from the HTTP request and declare them as handler parameters: for example, adding a `State` extractor means we want to include the state that we added to our `axum::Router`. Then we want to implement `sqlx::FromRow` using a derive macro for our struct - doing this allows it to automatically be converted from a query:
 
@@ -175,7 +175,7 @@ async fn create_record(
             .execute(&state.db)
             .await {
                 return Err(
-                    (StatusCode::INTERNAL_SERVER_ERROR, 
+                    (StatusCode::INTERNAL_SERVER_ERROR,
                     format!("Error while inserting a record: {e}"))
                 );
             }
@@ -192,7 +192,7 @@ async fn delete_record_by_id(
             .fetch_all(&state.db)
             .await {
                 return Err((
-                    StatusCode::INTERNAL_SERVER_ERROR, 
+                    StatusCode::INTERNAL_SERVER_ERROR,
                     format!("Error while deleting a record: {e}"))
                 );
             }
@@ -215,10 +215,10 @@ async fn update_record_by_id(
     Path(id): Path<i32>,
     Json(json): Json<UserSubmission>
 ) -> Result<impl IntoResponse, impl IntoResponse> {
-        if let Err(e) = sqlx::query("UPDATE USERS (name, age) 
+        if let Err(e) = sqlx::query("UPDATE USERS (name, age)
             SET name = (case when $1 is not null then $1 else name end),
             age = (case when $2 is not null then $2 else age end)
-            WHERE 
+            WHERE
             id = $3")
             .bind(json.name)
             .bind(json.age)
@@ -226,7 +226,7 @@ async fn update_record_by_id(
             .execute(&state.db)
             .await {
                 return Err(
-                    (StatusCode::INTERNAL_SERVER_ERROR, 
+                    (StatusCode::INTERNAL_SERVER_ERROR,
                     format!("Error while inserting a record: {e}"))
                 );
             }
@@ -240,11 +240,11 @@ Now that we’ve written all of our routes, we can append them to the router lik
 ```rust
 let router = Router::new()
     .route("/", get(hello_world))
-    .route("/users", 
+    .route("/users",
         get(retrieve_all_records)
         .post(create_record)
      )
-    .route("/users/:id", 
+    .route("/users/:id",
         get(retrieve_record_by_id)
         .put(update_record_by_id)
         .delete(delete_record_by_id)
@@ -256,7 +256,7 @@ Need to double check what the deployment code looks like? You can find it in [th
 
 ## Deployment
 
-Now that we’ve finished, the only thing left to do is deploying the Rust application. You can run `cargo shuttle deploy` (with the `--allow-dirty` flag if working on a dirty Git branch) and deploy with one line!
+Now that we’ve finished, the only thing left to do is deploying the Rust application. You can run `shuttle deploy` (with the `--allow-dirty` flag if working on a dirty Git branch) and deploy with one line!
 
 ## Extending this example
 
@@ -267,7 +267,7 @@ Looking to extend the project from this article? Here’s a couple of ways you c
 
 ## Finishing Up
 
-Thanks for reading! Hopefully this article has helped you deploy your first API in Rust. With the backend framework ecosystem already being in a relatively mature state, it's becoming easier than ever to write powerful and performant but low-memory footprint web services in Rust. 
+Thanks for reading! Hopefully this article has helped you deploy your first API in Rust. With the backend framework ecosystem already being in a relatively mature state, it's becoming easier than ever to write powerful and performant but low-memory footprint web services in Rust.
 
 Further reading:
 

--- a/_blog/2024-02-08-uptime-monitoring-rust.mdx
+++ b/_blog/2024-02-08-uptime-monitoring-rust.mdx
@@ -12,14 +12,14 @@ In this article, we’re going to talk about building and deploying an uptime-mo
 
 Interested in just deploying your uptime monitor? You can find that in 2 steps:
 
-1. Open your terminal and run `cargo shuttle init --from joshua-mo-143/shuttle-monitoring-template`  (requires `cargo-shuttle` installed) and follow the prompt
-2. Run `cargo shuttle deploy --allow-dirty` and watch the magic happen!
+1. Open your terminal and run `shuttle init --from joshua-mo-143/shuttle-monitoring-template`  (requires `cargo-shuttle` installed) and follow the prompt
+2. Run `shuttle deploy --allow-dirty` and watch the magic happen!
 
 For everyone who wants to learn how to build it, let’s get started - if you get lost, you can find the repo with the final code [here.](https://github.com/joshua-mo-143/shuttle-monitoring-template)
 
 ## Getting Started
 
-Firstly, we’ll initialize our project using `cargo shuttle init` (requires `cargo-shuttle` to be installed). Make sure you pick Axum as the framework!
+Firstly, we’ll initialize our project using `shuttle init` (requires `cargo-shuttle` to be installed). Make sure you pick Axum as the framework!
 
 Now you’ll want to install all of your dependencies. You can do that with the following shell snippet below:
 
@@ -690,7 +690,7 @@ async fn main(#[shuttle_shared_db::Postgres] db: PgPool) -> shuttle_axum::Shuttl
 
 ## Deploying
 
-Now it’s time to deploy! Type in `cargo shuttle deploy` (add `--allow-dirty` if on a dirty Git branch) and watch the magic happen. When your program has deployed, it’ll give you the URL of your deployment where you can try it out as well as deployment ID and other details like your database connection (password is hidden until you use the `--show-secrets` flag).
+Now it’s time to deploy! Type in `shuttle deploy` (add `--allow-dirty` if on a dirty Git branch) and watch the magic happen. When your program has deployed, it’ll give you the URL of your deployment where you can try it out as well as deployment ID and other details like your database connection (password is hidden until you use the `--show-secrets` flag).
 
 ## Finishing up
 

--- a/_blog/2024-02-13-clerk-in-react.mdx
+++ b/_blog/2024-02-13-clerk-in-react.mdx
@@ -492,7 +492,7 @@ This will generate an optimized build in the `/frontend/dist` directory.
 Finally run the backend using:
 
 ```bash
-cargo shuttle run
+shuttle run
 ```
 
 Open the highlighted URL in the browser window:
@@ -501,7 +501,7 @@ Open the highlighted URL in the browser window:
 
 ## Deployment
 
-Now you can deploy your app on the Shuttle platform by running `cargo shuttle start` and `cargo shuttle deploy` (with the `--allow-dirty` flag if you have uncommitted changes).
+Now you can deploy your app on the Shuttle platform by running `shuttle deploy` (with the `--allow-dirty` flag if you have uncommitted changes).
 
 One important note is that the deployment using the **development** keys from Clerk will work just fine, but if you change to use the **Production Instance** of Clerk then you will need to update the keys with **Live** keys. Now since you have moved to production you will also need to set up the domain or subdomain of your application in Clerk and add the CNAME records that you will get from the Clerk dashboard to your DNS record for managing sessions, loading portal using your domain, sending verification emails, and using custom callback URL. Since this process can be different based on your domain provider and management system, I will leave a link to the Clerks documentation on [**Deploy to production**](https://clerk.com/docs/deployments/overview).
 

--- a/_blog/2024-02-21-using-jwt-auth-rust.mdx
+++ b/_blog/2024-02-21-using-jwt-auth-rust.mdx
@@ -3,7 +3,7 @@ title: "Implementing JWT Authentication in Rust"
 description: "Using JSON Web Tokens (JWTs) when implementing authentication in a Rust API"
 author: josh
 tags: [rust, auth, jwt, guide]
-thumb: jwt-auth-rust-thumb.png 
+thumb: jwt-auth-rust-thumb.png
 cover: jwt-auth-rust-thumb.png
 date: '2024-02-21T15:00:00'
 ---
@@ -18,7 +18,7 @@ JWTs are a popular option when deciding on an auth strategy. The client stores a
 
 ## Getting started
 
-To get started, let’s initialise a project using `cargo shuttle init`, making sure to pick Axum as the framework. 
+To get started, let’s initialise a project using `shuttle init`, making sure to pick Axum as the framework.
 
 Then we’ll add our dependencies:
 
@@ -66,7 +66,7 @@ static KEYS: Lazy<Keys> = Lazy::new(|| {
 });
 ```
 
-Note that there’s many different sources you can use to generate the byte array from for this - generating a random string and turning it into bytes is just one of them. For production usage, you may also want to use a cryptographically safe algorithm. 
+Note that there’s many different sources you can use to generate the byte array from for this - generating a random string and turning it into bytes is just one of them. For production usage, you may also want to use a cryptographically safe algorithm.
 
 ### Writing our JWT Claim
 
@@ -224,7 +224,7 @@ async fn main() -> shuttle_axum::ShuttleAxum {
 
 ### Testing
 
-To test that the API works, we can use `cargo shuttle run` to serve the API locally. 
+To test that the API works, we can use `shuttle run` to serve the API locally.
 
 To test our `/login` endpoint, we’ll send a cURL request to it with the data:
 
@@ -249,7 +249,7 @@ Welcome to the protected area, foo!
 
 ## Deploying
 
-Now that we’ve written our whole project, we can deploy! Type in `cargo shuttle deploy` and press enter (add `--ad` flag if on a dirty Git branch to allow dirty deploys). When finished, our terminal should print out all of the data about our deployment and project and a link to the live project!
+Now that we’ve written our whole project, we can deploy! Type in `shuttle deploy` and press enter (add `--ad` flag if on a dirty Git branch to allow dirty deploys). When finished, our terminal should print out all of the data about our deployment and project and a link to the live project!
 
 ## Extending this project
 

--- a/_blog/2024-02-22-api-rate-limiting-rust.mdx
+++ b/_blog/2024-02-22-api-rate-limiting-rust.mdx
@@ -116,7 +116,7 @@ For external-facing websites without a login, IP addresses are the only thing yo
 Working with user-based rate limiting allows us to solve these issues. While users can have more than one IP address, we can assign it all to the same user.
 
 ## Getting started
-To initialise our web service we'll use `cargo shuttle init` (requires `cargo-shuttle` installed) to create our project, making sure to pick Axum as the framework.
+To initialise our web service we'll use `shuttle init` (requires `cargo-shuttle` installed) to create our project, making sure to pick Axum as the framework.
 
 Before adding the rate limiter itself, we’re going to create a custom header key! This will be used in routes where we require user authentication. We can also use the header when implementing our custom key extractor for the rate limiter later on. We’ll want to start by adding `axum-extra` with the `typed-header` feature:
 
@@ -268,7 +268,7 @@ Note that in the builder, the `per_second()` function tells us exactly how many 
 
 ## Deploying
 
-Now that we’re done, you can deploy using `cargo shuttle deploy` (add `--ad` if on a dirty Git branch) and watch the magic happen. Once finished, Shuttle will output the details of your deployment in the terminal.
+Now that we’re done, you can deploy using `shuttle deploy` (add `--ad` if on a dirty Git branch) and watch the magic happen. Once finished, Shuttle will output the details of your deployment in the terminal.
 
 ## Finishing Up
 

--- a/_blog/2024-02-28-rag-llm-rust.mdx
+++ b/_blog/2024-02-28-rag-llm-rust.mdx
@@ -12,9 +12,9 @@ Hey there! Today, we’re going to talk about creating a web application that ut
 
 Interested in deploying or wanting to fiddle around with the code yourself? You can find the repo [here](https://github.com/joshua-mo-143/shuttle-qdrant-template). You can deploy it in three steps:
 
-- Use `cargo shuttle init --from joshua-mo-143/shuttle-qdrant-template` and follow the prompt
+- Use `shuttle init --from joshua-mo-143/shuttle-qdrant-template` and follow the prompt
 - Add your API keys (see Pre-requisites for this)
-- Use `cargo shuttle deploy --allow-dirty` to deploy and wait for the magic to happen!
+- Use `shuttle deploy --allow-dirty` to deploy and wait for the magic to happen!
 
 ## What is Retrieval Augmented Generation?
 
@@ -55,7 +55,7 @@ assets = ["docs/*"]
 
 ### Installing and project initialisation
 
-To get started, we’ll generate a new application using `cargo shuttle init` (requires `cargo-shuttle` installed). Make sure to pick Axum as the framework!
+To get started, we’ll generate a new application using `shuttle init` (requires `cargo-shuttle` installed). Make sure to pick Axum as the framework!
 
 We’ll need to add some dependencies, which we can do with the following shell snippet:
 
@@ -519,7 +519,7 @@ Note that every time you spin this up, it will attempt to embed the documentatio
 
 ## Deploying
 
-Now that we’re at the end, we can deploy! Run `cargo shuttle deploy` (with `--allow-dirty` attached) and `cargo-shuttle` will automatically make the magic happen. When finished, you’ll receive some data about your deployment and a link to your deployed project.
+Now that we’re at the end, we can deploy! Run `shuttle deploy` (with `--allow-dirty` attached) and `cargo-shuttle` will automatically make the magic happen. When finished, you’ll receive some data about your deployment and a link to your deployed project.
 
 ## Finishing up
 

--- a/_blog/2024-02-29-fullstack-loco-rust.mdx
+++ b/_blog/2024-02-29-fullstack-loco-rust.mdx
@@ -12,9 +12,9 @@ Loco is a Rust framework that aims to do it all - authentication, tasks, migrati
 In this guide, we’ll deploying Loco on Shuttle via a fullstack template that also additionally includes SaaS subscription payments. By using their SaaS starter, we can leverage their pre-built authentication features to build payments out quickly and easily.  Interested in deploying or trying out the final repo? You can check it out [here.](https://github.com/joshua-mo-143/shuttle-stripe-ex)
 
 Steps to deploy from cloning:
-- Run `cargo shuttle init --from joshua-mo-143/shuttle-stripe-ex` and follow the prompt (requires `cargo-shuttle` installed)
+- Run `shuttle init --from joshua-mo-143/shuttle-stripe-ex` and follow the prompt (requires `cargo-shuttle` installed)
 - Set up API keys (see below)
-- Use `cargo shuttle deploy --allow-dirty` and watch the magic happen!
+- Use `shuttle deploy --allow-dirty` and watch the magic happen!
 
 ## Prerequisites
 
@@ -28,15 +28,15 @@ STRIPE_API_KEY = "<YOUR-STRIPE-KEY-HERE>"
 
 ### Getting started
 
-We’re going to use the following command to initialise our project (requires `cargo-shuttle` installed), following the prompt to initialise a project with our name. The `--from` flag allows us to take the starter from 
+We’re going to use the following command to initialise our project (requires `cargo-shuttle` installed), following the prompt to initialise a project with our name. The `--from` flag allows us to take the starter from
 
 ```bash
-cargo shuttle init --from loco-rs/loco --subfolder starters/saas
+shuttle init --from loco-rs/loco --subfolder starters/saas
 ```
 
 We will then use `cargo loco generate deployment` to generate a Shuttle deployment for our Loco project!
 
-While we’re here, make sure you’re using the latest version of `cargo-shuttle` and Shuttle dependencies in your project. We released v0.40.0 today! 
+While we’re here, make sure you’re using the latest version of `cargo-shuttle` and Shuttle dependencies in your project. We released v0.40.0 today!
 
 We’ll also add the following dependencies with a shell snippet:
 
@@ -79,7 +79,7 @@ async fn main(
 
 In the regular `src/bin/main.rs`, you may also need to adjust the app so that `Migrator` is also included.
 
-Once done, you can use `cargo shuttle run` and it should just automatically work! You’ll get a database connection URL (save this for later!).
+Once done, you can use `shuttle run` and it should just automatically work! You’ll get a database connection URL (save this for later!).
 
 ### Migrations
 
@@ -97,13 +97,13 @@ DATABASE_URL=<DB_URL_HERE> cargo loco db migrate
 DATABASE_URL=<DB_URL_HERE> cargo loco db entities
 ```
 
- Note that you will need a database URL for this. If you don’t have one yet, you can use `cargo shuttle run` to automatically spin up a Postgres container with a provided connection string or spin up your own Docker container.
+ Note that you will need a database URL for this. If you don’t have one yet, you can use `shuttle run` to automatically spin up a Postgres container with a provided connection string or spin up your own Docker container.
 
 These two commands will generate some files in the `migrations` folder as well as in `src/models`, which we’ll be making heavy use of as they are the main way to interface with the database when using Loco.
 
 ## Frontend
 
-We won’t be covering the frontend in this tutorial as there’s a lot of different ways you can do it - however, if you’d like to look at the way that we’ve done it, feel free to check out the repo here! We use React as provided by Loco with `react-router-dom` for routing and `zustand` for state management, with vanilla CSS. 
+We won’t be covering the frontend in this tutorial as there’s a lot of different ways you can do it - however, if you’d like to look at the way that we’ve done it, feel free to check out the repo here! We use React as provided by Loco with `react-router-dom` for routing and `zustand` for state management, with vanilla CSS.
 
 The following pages in the repo have been provided:
 
@@ -161,7 +161,7 @@ impl IntoResponse for ApiError {
 
 ## Using Stripe
 
-To get started with using Stripe, we’ll want to create a new loco controller file that will hold all of our routes. We can do this with `cargo loco generate controller stripe`, which will generate a new controller route at `src/controllers/stripe.rs` and inject some code into `src/app.rs` to make sure the controller gets automatically included. 
+To get started with using Stripe, we’ll want to create a new loco controller file that will hold all of our routes. We can do this with `cargo loco generate controller stripe`, which will generate a new controller route at `src/controllers/stripe.rs` and inject some code into `src/app.rs` to make sure the controller gets automatically included.
 
 Looking inside `src/controllers/stripe.rs` should give you a function that returns `Routes` (a struct that builds on `axum::Router`) and a couple of routes for returning “Hello, world!” and the contents of a given request.
 
@@ -208,14 +208,14 @@ impl fmt::Display for UserTier {
 }
 ```
 
-Note that the macros we are importing from `sea_orm` will let the enum be stored as a `varchar` type in Postgres. 
+Note that the macros we are importing from `sea_orm` will let the enum be stored as a `varchar` type in Postgres.
 
 ### Creating Stripe products and prices
 
 Before we do anything else, we will want to create a Stripe product that has some prices attached to it. To do that, we can create two functions; one for creating the Product item, and then one for adding a price (as products on Stripe can have multiple prices). Creating a price requires a product. To keep it simple, we’ll keep one price attached to one item. Both functions will be used as part of other functions.
 
 ```rust
-use stripe::{Client, Product, Price, CreatePrice, CreateProduct, IdOrCreate, 
+use stripe::{Client, Product, Price, CreatePrice, CreateProduct, IdOrCreate,
 CreatePriceRecurring, CreatePriceRecurringInterval, Currency};
 
 async fn create_product_item(client: &Client, user_tier: &UserTier) -> Result<Product, ApiError> {
@@ -311,7 +311,7 @@ async fn retrieve_product(
 }
 ```
 
-Later on, when we run the web service, the API should automatically be able to know if it is required to remake the Stripe product or not. 
+Later on, when we run the web service, the API should automatically be able to know if it is required to remake the Stripe product or not.
 
 Let’s write a function for creating a subscription. To get started, we will define what the JSON input should look like when the API receives a request:
 
@@ -329,9 +329,9 @@ pub struct UserSubscription {
 }
 ```
 
-Note that when sending the request, the variables must be in camel case and not snake case. 
+Note that when sending the request, the variables must be in camel case and not snake case.
 
-To make things a little bit easier for ourselves later, we will add an `impl` for `UserSubscription` which will allow us to automatically turn it into some structs that we’ll be using later on to create the customer and `CardDetailsParams`. 
+To make things a little bit easier for ourselves later, we will add an `impl` for `UserSubscription` which will allow us to automatically turn it into some structs that we’ll be using later on to create the customer and `CardDetailsParams`.
 
 ```rust
 impl UserSubscription {
@@ -379,17 +379,17 @@ pub async fn create_subscription(
 ) -> Result<StatusCode, ApiError> {
     let secret_key = std::env::var("STRIPE_API_KEY").expect("Missing STRIPE_API_KEY in env");
     let client = Client::new(secret_key);
-    
+
     // .. rest of your code
 }
 ```
 
-Here, note that we specifically use the `JWTWithUser` middleware to extract a Bearer JWT from the Authorization header and return a user model. 
+Here, note that we specifically use the `JWTWithUser` middleware to extract a Bearer JWT from the Authorization header and return a user model.
 
 Next, we want to create a customer and add it to our Stripe account. We will also create the payment method and attach it to the customer. Note here that while we’re using card payments as it’s a very common form of payment, Stripe also has quite a few other types of payments you can try.
 
 ```rust
-use stripe::{Customer, PaymentMethod, PaymentMethodTypeFilter, 
+use stripe::{Customer, PaymentMethod, PaymentMethodTypeFilter,
 CreatePaymentMethodCardUnion, AttachPaymentMethod};
 
 let customer = Customer::create(&client, json.as_create_customer()).await?;
@@ -541,7 +541,7 @@ if new_user_tier.user_tier == user_subscription.user_tier {
 }
 ```
 
-Once done, we can then find the subscription tier data from our database according to the requested tier change and update the subscription using the new tier’s Stripe price object ID. 
+Once done, we can then find the subscription tier data from our database according to the requested tier change and update the subscription using the new tier’s Stripe price object ID.
 
 ```rust
 let new_subscription = subscription_tiers::Entity
@@ -571,7 +571,7 @@ let updated_subscription = Subscription::update(
 ).await?;
 ```
 
-Before we finish this function up, we will need to update the user tier in the `user_subscriptions` table. 
+Before we finish this function up, we will need to update the user tier in the `user_subscriptions` table.
 
 ```rust
 use sea_orm::IntoActiveModel;
@@ -623,7 +623,7 @@ pub fn routes() -> Routes {
 
 ## Deployment
 
-To deploy, you just need to run `cargo shuttle deploy --allow-dirty` and let Shuttle make the magic happen! Once done, you’ll see information about your service.
+To deploy, you just need to run `shuttle deploy --allow-dirty` and let Shuttle make the magic happen! Once done, you’ll see information about your service.
 
 ## Finishing up
 

--- a/_blog/2024-03-13-simple-web-server-rust.mdx
+++ b/_blog/2024-03-13-simple-web-server-rust.mdx
@@ -23,7 +23,7 @@ Additionally, we also have an article about what framework you should use [here.
 
 To get started, you’ll want Rust installed on your system. Don’t have it installed? You can get it from [this install page.](https://www.rust-lang.org/tools/install)
 
-Next, you’ll want to use `cargo shuttle init` (requires `cargo-shuttle` installed). and then pick `Axum` for our framework.
+Next, you’ll want to use `shuttle init` (requires `cargo-shuttle` installed). and then pick `Axum` for our framework.
 
 ## Hello world!
 
@@ -268,7 +268,7 @@ let router = Router::new()
 
 ## Deployment
 
-To deploy Rust to Shuttle, you can use `cargo shuttle deploy` and watch the magic happen! Don’t forget to add the `--allow-dirty` flag if on a Git branch with uncommitted changes. Besides web server development, Shuttle is a lifesaver when it comes to easily deploying and making your web service public.
+To deploy Rust to Shuttle, you can use `shuttle deploy` and watch the magic happen! Don’t forget to add the `--allow-dirty` flag if on a Git branch with uncommitted changes. Besides web server development, Shuttle is a lifesaver when it comes to easily deploying and making your web service public.
 
 Interested? You can find our docs [here.](https://docs.shuttle.rs/introduction/welcome)
 

--- a/_blog/2024-03-20-notification-service-rust.mdx
+++ b/_blog/2024-03-20-notification-service-rust.mdx
@@ -26,7 +26,7 @@ To get started, you will need two keys from AWS:
 
 ## Receiving AWS SNS messages
 
-To start with, let’s have a look at how we can receive SNS messages. We can do this with `cargo shuttle init`, picking Axum as our framework. This service will have a single endpoint that takes the SNS messages and prints the message out.
+To start with, let’s have a look at how we can receive SNS messages. We can do this with `shuttle init`, picking Axum as our framework. This service will have a single endpoint that takes the SNS messages and prints the message out.
 
 To make this idiomatic, we’ll want to create a struct called `SnsMessage` that implements `axum::FromRequest`. This will allow us to use it as an extractor, rather than trying to parse the POST requests from SNS manually.
 
@@ -111,7 +111,7 @@ Now it’s complete!
 
 ### Deploying
 
-To deploy, you can use `cargo shuttle deploy` (with `--allow-dirty` if on a Git branch and uncommitted changes). Take note of the deployment URL! We will need this later on.
+To deploy, you can use `shuttle deploy` (with `--allow-dirty` if on a Git branch and uncommitted changes). Take note of the deployment URL! We will need this later on.
 
 ## Sending AWS SNS messages
 
@@ -119,7 +119,7 @@ Now for the second part of our notification service: sending messages to our rec
 
 ### Setup
 
-We’ll get started by using `cargo shuttle init` once again, picking Axum as our choice of framework. Make sure to follow the prompt until the end to finalise your project.
+We’ll get started by using `shuttle init` once again, picking Axum as our choice of framework. Make sure to follow the prompt until the end to finalise your project.
 
 Once done, we can install our dependencies with this script:
 
@@ -153,7 +153,7 @@ async fn main(
 }
 ```
 
-When we use `cargo shuttle run`, our secrets will now get provisioned to us without needing to do anything!
+When we use `shuttle run`, our secrets will now get provisioned to us without needing to do anything!
 
 Before we start adding more code, let’s write our `AppState` struct to hold Axum state. This will allow our handler functions to access our AWS SNS client whenever we want.
 
@@ -385,7 +385,7 @@ async fn main(#[shuttle_secrets::Secrets] secrets: SecretStore) -> shuttle_axum:
 
 ## Deploying
 
-To deploy, we just need to use `cargo shuttle deploy` (with the `--allow-dirty` flag if on an uncommitted Git branch) and watch the magic happen!
+To deploy, we just need to use `shuttle deploy` (with the `--allow-dirty` flag if on an uncommitted Git branch) and watch the magic happen!
 
 ## Finishing up
 

--- a/_blog/2024-03-28-grafana-rust.mdx
+++ b/_blog/2024-03-28-grafana-rust.mdx
@@ -24,7 +24,7 @@ To get the most out of this article, you need to either self-host Grafana servic
 
 To get started, you will want an API token that has the `write:logs` permissions. This can be done from Grafana Cloud user management. Make sure you save your Grafana user and API token variables, as you’ll need them in just a little bit.
 
-For initializing our service, we’ll use `cargo shuttle init --template axum`  (requires `cargo-shuttle` installed) to create a new Shuttle project with the Axum template. We will then add the following dependencies with this shell snippet:
+For initializing our service, we’ll use `shuttle init --template axum`  (requires `cargo-shuttle` installed) to create a new Shuttle project with the Axum template. We will then add the following dependencies with this shell snippet:
 
 ```bash
 cargo add url
@@ -35,7 +35,7 @@ cargo add base64
 cargo add shuttle-runtime --no-default-features
 ```
 
-We’ll also additionally need to add the `#[shuttle_runtime::Secrets]` annotation macro to our main function. This allows us to automatically grab secrets from our Secrets.toml file when we use `cargo shuttle run` to run our Shuttle service. It should look like this:
+We’ll also additionally need to add the `#[shuttle_runtime::Secrets]` annotation macro to our main function. This allows us to automatically grab secrets from our Secrets.toml file when we use `shuttle run` to run our Shuttle service. It should look like this:
 
 ```rust
 [..]
@@ -149,7 +149,7 @@ async fn main(
 }
 ```
 
-When using `cargo shuttle run` now, your terminal will become populated with traces. If you visit `localhost:8000` in the browser, you should see a debug tracing event with the description `An event happened!` in your traces. Note that it may take Grafana 5-10 minutes to receive your traces.
+When using `shuttle run` now, your terminal will become populated with traces. If you visit `localhost:8000` in the browser, you should see a debug tracing event with the description `An event happened!` in your traces. Note that it may take Grafana 5-10 minutes to receive your traces.
 
 ## Reading your logs
 
@@ -159,7 +159,7 @@ The label we added to our logs should show up under the `Labels` column. It will
 
 ## Deploying
 
-To deploy, simply use `cargo shuttle deploy` and watch the magic happen!
+To deploy, simply use `shuttle deploy` and watch the magic happen!
 
 ## Finishing up
 

--- a/_blog/2024-04-17-using-aws-s3-rust.mdx
+++ b/_blog/2024-04-17-using-aws-s3-rust.mdx
@@ -53,7 +53,7 @@ When using S3-compatible APIs, this may look different depending on the service 
 
 ## Getting started
 
-To get started, we’ll create a Shuttle service via `cargo shuttle init`, making sure to pick the Axum framework. Make sure you have `cargo-shuttle` installed!
+To get started, we’ll create a Shuttle service via `shuttle init`, making sure to pick the Axum framework. Make sure you have `cargo-shuttle` installed!
 
 Next, you’ll want to install the following Rust dependencies using the following shell snippet:
 
@@ -502,7 +502,7 @@ async fn my_test() {
 
 ## Deploying
 
-To deploy our web service, all we need to do now is `cargo shuttle deploy`! Make sure to add the `--allow-dirty` flag if on a Git branch with uncommitted changes. If you’ve added tests, make sure to add the `--no-test` flag, as they may not work while deploying. One quick workaround for this is to add a test workflow before deployment.
+To deploy our web service, all we need to do now is `shuttle deploy`! Make sure to add the `--allow-dirty` flag if on a Git branch with uncommitted changes. If you’ve added tests, make sure to add the `--no-test` flag, as they may not work while deploying. One quick workaround for this is to add a test workflow before deployment.
 
 ## Finishing up
 

--- a/_blog/2024-04-25-event-driven-services-using-kafka-rust.mdx
+++ b/_blog/2024-04-25-event-driven-services-using-kafka-rust.mdx
@@ -39,7 +39,7 @@ If you want to deploy this service to the web somewhere, you’ll also want to m
 
 ### Project setup
 
-To get started, we’ll want to make a new project using `cargo shuttle init` - don’t forget to select Axum as the framework! You will need `cargo-shuttle` installed for this. If you don’t have it installed, you can use `cargo install cargo-shuttle`.
+To get started, we’ll want to make a new project using `shuttle init` - don’t forget to select Axum as the framework! You will need `cargo-shuttle` installed for this. If you don’t have it installed, you can use `cargo install cargo-shuttle`.
 
 We’ll then want to use the following shell snippet to install our project dependencies:
 
@@ -393,7 +393,7 @@ let rtr = Router::new()
      .with_state(state);
 ```
 
-If you use `cargo shuttle run` to start your application (assuming Kafka is running) and run this curl command:
+If you use `shuttle run` to start your application (assuming Kafka is running) and run this curl command:
 
 ```bash
 	curl localhost:8000/send -H 'Content-Type: application/json' \
@@ -695,7 +695,7 @@ The address will link directly to the Kafka node which we can connect to and cre
 
 ## Deploying
 
-To deploy, simply write `cargo shuttle deploy --ad` and watch the magic happen! Once you’ve compiled the first time, you’ll benefit from incremental deployment compilations.
+To deploy, simply write `shuttle deploy --ad` and watch the magic happen! Once you’ve compiled the first time, you’ll benefit from incremental deployment compilations.
 
 ## Finishing up
 

--- a/_blog/2024-05-01-using-huggingface-rust.mdx
+++ b/_blog/2024-05-01-using-huggingface-rust.mdx
@@ -536,7 +536,7 @@ Of course, when you try to run this locally you may notice that CPU performance 
 
 GPU usage is gated by the use of the “CUDA” - Compute Unified Device Architecture - toolkit (and is a feature flag of `candle_core`). However, this would be difficult to use on the web unless you can have CUDA preinstalled. Nevertheless, it unlocks performance enhancing features outside of just your GPU. For example, Flash Attention, a technique that improves inference speeds with better parallelism and work partitioning. You can find the Arvix paper [here.](https://tridao.me/publications/flash2/flash2.pdf)
 
-This is even more noticeable when you’re running in debug mode. To alleviate this, you can run in release mode using `cargo shuttle run --release` (or without Shuttle: `cargo run --release`). This will run the release profile of your application, which is much more optimised.
+This is even more noticeable when you’re running in debug mode. To alleviate this, you can run in release mode using `shuttle run --release` (or without Shuttle: `cargo run --release`). This will run the release profile of your application, which is much more optimised.
 
 ## Finishing up
 

--- a/_blog/2024-05-10-prompting-aws-bedrock-rust.mdx
+++ b/_blog/2024-05-10-prompting-aws-bedrock-rust.mdx
@@ -53,7 +53,7 @@ In production, you may want to go a step further and create a Group that you can
 
 ### Initialisation
 
-To get started, we're going to use `cargo shuttle init` (requires `cargo-shuttle` installed) to initialise our template, picking Axum as the framework.
+To get started, we're going to use `shuttle init` (requires `cargo-shuttle` installed) to initialise our template, picking Axum as the framework.
 
 Next, we're going to add our dependencies:
 
@@ -433,7 +433,7 @@ async fn main(
 
 ## Deployment
 
-To deploy, all you need to do is `cargo shuttle deploy` (with the `--allow-dirty` flag if working from a Git branch with uncommitted changes) and watch the magic happen! Once finished, you’ll get a message containing information about your deployment as well as where you can reach the deployment URL.
+To deploy, all you need to do is `shuttle deploy` (with the `--allow-dirty` flag if working from a Git branch with uncommitted changes) and watch the magic happen! Once finished, you’ll get a message containing information about your deployment as well as where you can reach the deployment URL.
 
 Shuttle will also cache your dependencies, so if you need to re-deploy you won’t have to worry about waiting to re-compile!
 

--- a/_blog/2024-05-16-building-ai-content-writer-rust-gpt4o.mdx
+++ b/_blog/2024-05-16-building-ai-content-writer-rust-gpt4o.mdx
@@ -360,7 +360,7 @@ We can then hook it all up by adding our endpoint to the router:
 
 ## Deployment
 
-Now all we need to do is use `cargo shuttle deploy` (adding the `--ad` flag if on an uncommitted Git branch) and watch the magic happen!
+Now all we need to do is use `shuttle deploy` (adding the `--ad` flag if on an uncommitted Git branch) and watch the magic happen!
 
 ## Extending this project
 

--- a/_blog/2024-05-23-building-agentic-rag-rust-qdrant.mdx
+++ b/_blog/2024-05-23-building-agentic-rag-rust-qdrant.mdx
@@ -19,7 +19,7 @@ Essentially, the difference between this workflow and a regular agent workflow w
 
 ## Getting Started
 
-To get started, use `cargo shuttle init` to create a new project.
+To get started, use `shuttle init` to create a new project.
 
 Next, we'll add the dependencies we need using a shell snippet:
 
@@ -381,7 +381,7 @@ async fn main(
 
 ## Deploying
 
-To deploy, all you need to do is use `cargo shuttle deploy` (with the `--ad` flag if on a Git branch with uncommitted changes), sit back and watch the magic happen!
+To deploy, all you need to do is use `shuttle deploy` (with the `--ad` flag if on a Git branch with uncommitted changes), sit back and watch the magic happen!
 
 ## Finishing Up
 

--- a/_blog/2024-05-30-semantic-caching-qdrant-rust.mdx
+++ b/_blog/2024-05-30-semantic-caching-qdrant-rust.mdx
@@ -40,7 +40,7 @@ Of course, there are good reasons **not** to use semantic caching. Prompts that 
 
 ### Getting started
 
-To get started, don't forget to use `cargo shuttle init`, with the Axum framework. We'll install our dependencies using the shell snippet below:
+To get started, don't forget to use `shuttle init`, with the Axum framework. We'll install our dependencies using the shell snippet below:
 
 ```bash
 cargo add qdrant-client@1.7.0 anyhow async-openai serde serde-json \
@@ -538,7 +538,7 @@ async fn main(
 
 ## Deploying
 
-To deploy, all you need to do is use `cargo shuttle deploy` (with the `--ad` flag if on a Git branch with uncommitted changes) and wait for it to deploy! Once you've deployed, any further deploys needed will only need to re-compile your application (and any extra dependencies if added) then it'll be done much, much faster.
+To deploy, all you need to do is use `shuttle deploy` (with the `--ad` flag if on a Git branch with uncommitted changes) and wait for it to deploy! Once you've deployed, any further deploys needed will only need to re-compile your application (and any extra dependencies if added) then it'll be done much, much faster.
 
 ## Extending this example
 


### PR DESCRIPTION
All articles now use the new platform and will use `shuttle` instead of `cargo shuttle`.