### PR TITLE
feat: added newsletter cta component to [slug] page

### DIFF
--- a/components/sections/CallToActionNewsletter.tsx
+++ b/components/sections/CallToActionNewsletter.tsx
@@ -3,69 +3,70 @@ import { trackEvent } from "lib/posthog";
 import Image from "next/image";
 
 interface CallToActionProps {
-  subtext?: string;
-  bg: boolean;
+    subtext?: string;
+    bg: boolean;
 }
 
 const CallToActionNewsletter = ({ subtext, bg }: CallToActionProps) => {
-  const subtext_ =
-    subtext ||
-    "Join the movement and help revolutionize the world of backend development. Together, we can create the future!";
-  return (
-    <div className="relative mt-11 flex w-full flex-col overflow-hidden rounded-[2rem] bg-[#13292C] p-8 dark:bg-black">
-      {bg == true ? (
-        <div>
-          <Image
-            src="/images/sections/powered-by/bg.png"
-            alt=""
-            fill
-            className="absolute left-0 top-0 z-10"
-          />
-          <Image
-            src="/images/sections/powered-by/stars.png"
-            alt=""
-            fill
-            className="absolute bottom-0 left-20 z-10"
-          />
-        </div>
-      ) : (
-        <div></div>
-      )}
+    const subtext_ =
+        subtext ||
+        "Join the movement and help revolutionize the world of backend development. Together, we can create the future!";
+    return (
+        <div className="relative flex w-full flex-col overflow-hidden rounded-[2rem] bg-[#13292C] p-0 dark:bg-black mt-4">
+            {bg == true ? (
+                <div>
+                    <Image
+                        src="/images/sections/powered-by/bg.png"
+                        alt=""
+                        fill
+                        className="absolute left-0 top-0 z-10"
+                    />
+                    <Image
+                        src="/images/sections/powered-by/stars.png"
+                        alt=""
+                        fill
+                        className="absolute bottom-0 left-20 z-10"
+                    />
+                </div>
+            ) : (
+                <div></div>
+            )}
 
-      <div className="max-w-2xl bg-[#13292C] p-8 dark:bg-transparent">
-        <h2 className="text-white  text-2xl font-bold  lg:text-3xl z-10">
-          Get Shuttle blog posts in your inbox
-        </h2>
-        <span className="relative z-10 mt-2 block text-body/80">
-          We&apos;ll send you complete blog posts via email - tutorials, guides,
-          collaborations, and product updates delivered straight to your inbox.
-        </span>
-        <form
-          action="https://buttondown.com/api/emails/embed-subscribe/shuttledev"
-          method="post"
-          target="popupwindow"
-          onSubmit={(e) => {
-            window.open("https://buttondown.com/shuttledev", "popupwindow");
-            trackEvent("homepage_newsletter_subscribe");
-          }}
-          className="mt-6 flex flex-col gap-4 md:flex-row md:items-end"
-        >
-          <div className="flex flex-col gap-2">
-            <input
-              type="email"
-              name="email"
-              id="bd-email"
-              placeholder="you@example.com"
-              className="w-72 rounded-lg bg-white/10 px-4 py-3 text-white placeholder:text-white/50 outline-none focus-visible:ring-2 focus-visible:ring-white z-10"
-            />
-          </div>
-          <Button variant="primary" type="submit">
-            <span className="relative z-10">Subscribe →</span>
-          </Button>
-        </form>
-      </div>
-    </div>
-  );
+            <div className="max-w-2xl bg-[#13292C] p-8 dark:bg-transparent">
+                <h2 className="text-white  text-2xl font-bold  lg:text-2xl z-10">
+                    Get Shuttle blog posts in your inbox
+                </h2>
+                {bg == true ? (<span className="relative z-10 mt-2 block text-body/80">
+                    We&apos;ll send you complete blog posts via email - tutorials, guides,
+                    collaborations, and product updates delivered straight to your inbox.
+                </span>) : (<> </>)}
+
+                <form
+                    action="https://buttondown.com/api/emails/embed-subscribe/shuttledev"
+                    method="post"
+                    target="popupwindow"
+                    onSubmit={(e) => {
+                        window.open("https://buttondown.com/shuttledev", "popupwindow");
+                        trackEvent("homepage_newsletter_subscribe");
+                    }}
+                    className="mt-6 flex flex-col gap-4 md:flex-row md:items-end"
+                >
+                    <div className="flex flex-col gap-2">
+                        <input
+                            type="email"
+                            name="email"
+                            id="bd-email"
+                            placeholder="you@example.com"
+                            className="w-72 rounded-lg bg-white/10 px-4 py-3 text-white placeholder:text-white/50 outline-none focus-visible:ring-2 focus-visible:ring-white z-10"
+                        />
+                    </div>
+                    <Button variant="primary" type="submit">
+                        <span className="relative z-10">Subscribe →</span>
+                    </Button>
+                </form>
+            </div>
+        </div>
+    );
 };
 
 export default CallToActionNewsletter;

--- a/components/sections/CallToActionNewsletter.tsx
+++ b/components/sections/CallToActionNewsletter.tsx
@@ -3,70 +3,69 @@ import { trackEvent } from "lib/posthog";
 import Image from "next/image";
 
 interface CallToActionProps {
-    subtext?: string;
-    bg: boolean
+  subtext?: string;
+  bg: boolean;
 }
 
 const CallToActionNewsletter = ({ subtext, bg }: CallToActionProps) => {
-    const subtext_ =
-        subtext ||
-        "Join the movement and help revolutionize the world of backend development. Together, we can create the future!";
-    return (
-        <div className="relative mt-11 flex w-full flex-col overflow-hidden rounded-[2rem] bg-[#13292C] p-8 dark:bg-black">
-            {bg == true ? (
-                <div>
-                    <Image
-                        src="/images/sections/powered-by/bg.png"
-                        alt=""
-                        fill
-                        className="absolute left-0 top-0 z-10"
-                    />
-                    <Image
-                        src="/images/sections/powered-by/stars.png"
-                        alt=""
-                        fill
-                        className="absolute bottom-0 left-20 z-10"
-                    />
-                </div>) : (<div></div>)}
-
-
-            <div className="max-w-2xl">
-                <h2 className="text-white  text-2xl font-bold  lg:text-3xl">
-                    Get Shuttle blog posts in your inbox
-                </h2>
-                <span className="relative z-10 mt-2 block text-body/80">
-                    We'll send you complete blog posts via email - tutorials, guides, collaborations, and product updates delivered straight to your inbox.
-                </span>
-                <form
-                    action="https://buttondown.com/api/emails/embed-subscribe/shuttledev"
-                    method="post"
-                    target="popupwindow"
-                    onSubmit={(e) => {
-                        window.open('https://buttondown.com/shuttledev', 'popupwindow');
-                        trackEvent("homepage_newsletter_subscribe");
-                    }}
-                    className="mt-6 flex flex-col gap-4 md:flex-row md:items-end"
-                >
-                    <div className="flex flex-col gap-2">
-
-                        <input
-                            type="email"
-                            name="email"
-                            id="bd-email"
-                            placeholder="you@example.com"
-                            className="w-72 rounded-lg bg-white/10 px-4 py-3 text-white placeholder:text-white/50 outline-none focus-visible:ring-2 focus-visible:ring-white"
-                        />
-                    </div>
-                    <Button
-                        variant="primary"
-                        type="submit"
-                    >
-                        <span className="relative z-10">Subscribe →</span>
-                    </Button>
-                </form>
-            </div>
+  const subtext_ =
+    subtext ||
+    "Join the movement and help revolutionize the world of backend development. Together, we can create the future!";
+  return (
+    <div className="relative mt-11 flex w-full flex-col overflow-hidden rounded-[2rem] bg-[#13292C] p-8 dark:bg-black">
+      {bg == true ? (
+        <div>
+          <Image
+            src="/images/sections/powered-by/bg.png"
+            alt=""
+            fill
+            className="absolute left-0 top-0 z-10"
+          />
+          <Image
+            src="/images/sections/powered-by/stars.png"
+            alt=""
+            fill
+            className="absolute bottom-0 left-20 z-10"
+          />
         </div>
-    );
+      ) : (
+        <div></div>
+      )}
+
+      <div className="max-w-2xl bg-[#13292C] p-8 dark:bg-transparent">
+        <h2 className="text-white  text-2xl font-bold  lg:text-3xl z-10">
+          Get Shuttle blog posts in your inbox
+        </h2>
+        <span className="relative z-10 mt-2 block text-body/80">
+          We'll send you complete blog posts via email - tutorials, guides,
+          collaborations, and product updates delivered straight to your inbox.
+        </span>
+        <form
+          action="https://buttondown.com/api/emails/embed-subscribe/shuttledev"
+          method="post"
+          target="popupwindow"
+          onSubmit={(e) => {
+            window.open("https://buttondown.com/shuttledev", "popupwindow");
+            trackEvent("homepage_newsletter_subscribe");
+          }}
+          className="mt-6 flex flex-col gap-4 md:flex-row md:items-end"
+        >
+          <div className="flex flex-col gap-2">
+            <input
+              type="email"
+              name="email"
+              id="bd-email"
+              placeholder="you@example.com"
+              className="w-72 rounded-lg bg-white/10 px-4 py-3 text-white placeholder:text-white/50 outline-none focus-visible:ring-2 focus-visible:ring-white z-10"
+            />
+          </div>
+          <Button variant="primary" type="submit">
+            <span className="relative z-10">Subscribe →</span>
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
 };
 
 export default CallToActionNewsletter;

--- a/components/sections/CallToActionNewsletter.tsx
+++ b/components/sections/CallToActionNewsletter.tsx
@@ -1,0 +1,72 @@
+import { Button } from "components/elements";
+import { trackEvent } from "lib/posthog";
+import Image from "next/image";
+
+interface CallToActionProps {
+    subtext?: string;
+    bg: boolean
+}
+
+const CallToActionNewsletter = ({ subtext, bg }: CallToActionProps) => {
+    const subtext_ =
+        subtext ||
+        "Join the movement and help revolutionize the world of backend development. Together, we can create the future!";
+    return (
+        <div className="relative mt-11 flex w-full flex-col overflow-hidden rounded-[2rem] bg-[#13292C] p-8 dark:bg-black">
+            {bg == true ? (
+                <div>
+                    <Image
+                        src="/images/sections/powered-by/bg.png"
+                        alt=""
+                        fill
+                        className="absolute left-0 top-0 z-10"
+                    />
+                    <Image
+                        src="/images/sections/powered-by/stars.png"
+                        alt=""
+                        fill
+                        className="absolute bottom-0 left-20 z-10"
+                    />
+                </div>) : (<div></div>)}
+
+
+            <div className="max-w-2xl">
+                <h2 className="text-white  text-2xl font-bold  lg:text-3xl">
+                    Get Shuttle blog posts in your inbox
+                </h2>
+                <span className="relative z-10 mt-2 block text-body/80">
+                    We'll send you complete blog posts via email - tutorials, guides, collaborations, and product updates delivered straight to your inbox.
+                </span>
+                <form
+                    action="https://buttondown.com/api/emails/embed-subscribe/shuttledev"
+                    method="post"
+                    target="popupwindow"
+                    onSubmit={(e) => {
+                        window.open('https://buttondown.com/shuttledev', 'popupwindow');
+                        trackEvent("homepage_newsletter_subscribe");
+                    }}
+                    className="mt-6 flex flex-col gap-4 md:flex-row md:items-end"
+                >
+                    <div className="flex flex-col gap-2">
+
+                        <input
+                            type="email"
+                            name="email"
+                            id="bd-email"
+                            placeholder="you@example.com"
+                            className="w-72 rounded-lg bg-white/10 px-4 py-3 text-white placeholder:text-white/50 outline-none focus-visible:ring-2 focus-visible:ring-white"
+                        />
+                    </div>
+                    <Button
+                        variant="primary"
+                        type="submit"
+                    >
+                        <span className="relative z-10">Subscribe →</span>
+                    </Button>
+                </form>
+            </div>
+        </div>
+    );
+};
+
+export default CallToActionNewsletter;

--- a/components/sections/CallToActionNewsletter.tsx
+++ b/components/sections/CallToActionNewsletter.tsx
@@ -37,7 +37,7 @@ const CallToActionNewsletter = ({ subtext, bg }: CallToActionProps) => {
           Get Shuttle blog posts in your inbox
         </h2>
         <span className="relative z-10 mt-2 block text-body/80">
-          We'll send you complete blog posts via email - tutorials, guides,
+          We&apos;ll send you complete blog posts via email - tutorials, guides,
           collaborations, and product updates delivered straight to your inbox.
         </span>
         <form

--- a/components/sections/index.tsx
+++ b/components/sections/index.tsx
@@ -28,3 +28,4 @@ export { default as Testimonials } from "./Testimonials";
 export { default as TrustedBy } from "./TrustedBy";
 export { default as Mission } from "./Mission";
 export { default as WorkingWithUs } from "./WorkingWithUs";
+export { default as CallToActionNewsletter } from "./CallToActionNewsletter";

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/pages/blog/[year]/[month]/[day]/[slug].tsx
+++ b/pages/blog/[year]/[month]/[day]/[slug].tsx
@@ -27,6 +27,7 @@ import {
   BlogPrevNext,
   BlogSidebar,
   CallToAction,
+  CallToActionNewsletter,
 } from "components/sections";
 import { LinkedInLogo, Logo, TwitterLogo } from "components/svgs";
 import { TwitterTweetEmbed } from "react-twitter-embed";
@@ -35,6 +36,7 @@ import MastodonLogo from "components/svgs/MastodonLogo";
 import HNLogo from "components/svgs/HNLogo";
 import { trackEvent } from "lib/posthog";
 import { TableOfContents } from "../../../../../components/blog/TableOfContents";
+import { Button } from "components/elements";
 
 export async function getStaticPaths() {
   const paths = getAllPostSlugs();
@@ -257,6 +259,7 @@ export default function BlogPostPage(props: Props) {
                 )}
               </div>
             )}
+            <CallToActionNewsletter bg={false} />
             {props.blog.contentTOC.json.length > 0 ? (
               <TableOfContents toc={props.blog.contentTOC.json} />
             ) : null}
@@ -278,37 +281,7 @@ export default function BlogPostPage(props: Props) {
               </article>
             )}
             {/* Powered By */}
-            <div className="relative mt-11 flex w-full flex-col overflow-hidden rounded-[2rem] bg-[#13292C] p-8 dark:bg-black">
-              <Image
-                src="/images/sections/powered-by/bg.png"
-                alt=""
-                fill
-                className="absolute left-0 top-0 z-10"
-              />
-              <Image
-                src="/images/sections/powered-by/stars.png"
-                alt=""
-                fill
-                className="absolute bottom-0 left-20 z-10"
-              />
-              <Logo className="relative z-10 text-white" />
-              <span className="relative z-10 mt-5 text-body">
-                This blog post is powered by shuttle - The Rust-native, open
-                source, cloud development platform. If you have any questions,
-                or want to provide feedback, join our{" "}
-                <a
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-orange"
-                  href={DISCORD_URL}
-                  onClick={() => {
-                    trackEvent(`blog_article_${props.blog.title}_Discord`);
-                  }}
-                >
-                  Discord server!
-                </a>
-              </span>
-            </div>
+            <CallToActionNewsletter bg={true} />
             {/* <Socials /> */}
             <div className="mb-20 mt-14 flex items-center space-x-4">
               <span className="text-head">Share article</span>

--- a/pages/blog/[year]/[month]/[day]/[slug].tsx
+++ b/pages/blog/[year]/[month]/[day]/[slug].tsx
@@ -82,7 +82,7 @@ export async function getStaticProps({
 
   const relatedPosts = getSortedPosts(
     6,
-    mdxPost.scope.tags as readonly string[]
+    mdxPost.scope.tags as readonly string[],
   )
     .filter((p) => p.slug != filePath)
     .slice(0, 5);
@@ -105,10 +105,10 @@ export async function getStaticProps({
   };
   const formattedPublishDate = new Date(data.date).toLocaleDateString(
     "en-IN",
-    options
+    options,
   );
   const formattedModifiedDate = new Date(
-    data.modified ?? data.date
+    data.modified ?? data.date,
   ).toLocaleDateString("en-IN", options);
   const pageTitle = data.pageTitle ?? data.title;
 
@@ -259,7 +259,7 @@ export default function BlogPostPage(props: Props) {
                 )}
               </div>
             )}
-            <CallToActionNewsletter bg={false} />
+            <CallToActionNewsletter bg={true} />
             {props.blog.contentTOC.json.length > 0 ? (
               <TableOfContents toc={props.blog.contentTOC.json} />
             ) : null}
@@ -274,7 +274,7 @@ export default function BlogPostPage(props: Props) {
                   "prose-headings:before:pt-36",
                   "prose-headings:lg:before:-mt-20",
                   "prose-headings:before:lg:pt-20",
-                  "text-xl text-body prose-h2:text-5xl prose-h3:text-4xl prose-h4:text-3xl prose-h5:text-2xl"
+                  "text-xl text-body prose-h2:text-5xl prose-h3:text-4xl prose-h4:text-3xl prose-h5:text-2xl",
                 )}
               >
                 <MDXRemote {...props.blog.content} components={mdxComponents} />
@@ -287,7 +287,7 @@ export default function BlogPostPage(props: Props) {
               <span className="text-head">Share article</span>
               <a
                 href={`https://news.ycombinator.com/submitlink?u=${encodeURIComponent(
-                  `${SITE_URL}blog/${props.blog.slug}`
+                  `${SITE_URL}blog/${props.blog.slug}`,
                 )}&t=${encodeURIComponent(props.blog.title)}`}
                 className="flex items-center rounded-xl border border-black/10 bg-black p-3 dark:border-white/10"
                 target="_blank"
@@ -300,7 +300,7 @@ export default function BlogPostPage(props: Props) {
               </a>
               <a
                 href={`https://twitter.com/share?text=${encodeURIComponent(
-                  props.blog.title
+                  props.blog.title,
                 )}&url=${SITE_URL}blog/${props.blog.slug}`}
                 className="flex items-center rounded-xl border border border-black/10 bg-black p-3 dark:border-white/10"
                 target="_blank"
@@ -330,11 +330,11 @@ export default function BlogPostPage(props: Props) {
                   trackEvent(`blog_article_${props.blog.title}_mastodon`);
 
                   const instance = window.prompt(
-                    "Enter your Mastodon instance (ex. mastodon.social):"
+                    "Enter your Mastodon instance (ex. mastodon.social):",
                   );
                   if (instance) {
                     window.location.href = `https://${instance}/share?text=${encodeURIComponent(
-                      `${props.blog.title} ${SITE_URL}blog/${props.blog.slug}`
+                      `${props.blog.title} ${SITE_URL}blog/${props.blog.slug}`,
                     )}`;
                   }
                 }}

--- a/pages/blog/[year]/[month]/[day]/[slug].tsx
+++ b/pages/blog/[year]/[month]/[day]/[slug].tsx
@@ -259,7 +259,7 @@ export default function BlogPostPage(props: Props) {
                 )}
               </div>
             )}
-            <CallToActionNewsletter bg={true} />
+            <CallToActionNewsletter bg={false} />
             {props.blog.contentTOC.json.length > 0 ? (
               <TableOfContents toc={props.blog.contentTOC.json} />
             ) : null}

--- a/pages/blog/tags/[tag].tsx
+++ b/pages/blog/tags/[tag].tsx
@@ -86,6 +86,7 @@ export default function BlogPage(props: Props): JSX.Element {
       />
 
       <FeaturedBlogPost {...headPost} />
+
       <Blog tags={tags} posts={tailPosts} />
     </>
   );


### PR DESCRIPTION
Added a component for the newsletter which we are implementing for the blog. The newsletter itself is setup on button down already, we just need to add relevant and non-intrusive CTAs to the blog. At the moment we've added one at the top of a blog post and one at the bottom. This should be enough in my opinion, but we may want to add one to the tags page as well.

There is a bug where the input is not responsive if the background image is used - this is for the input at the bottom of the post.