### PR TITLE
chore: remove link to blog at the end of the post

### DIFF
--- a/_blog/2024-08-23-rust-as-my-first-language.mdx
+++ b/_blog/2024-08-23-rust-as-my-first-language.mdx
@@ -99,8 +99,4 @@ I'm no computer scientist or full fledged software developer, I realize the thou
 
 Although I'm not the most qualified person in the world at Rust programming, I will continue to advocate for its use and adoption. I would encourage anyone interested to dive in head first and carve a unique path.
 
-## Shameless Self-Promotion
 
-I'm on the umpteenth iteration of my blog, the latest is at: [jeff-mitchell.dev.](https://jeff-mitchell.dev) Here you'll find everything I've written so far in the journey to learn Rust. I want it to be a "go to" for the examples, explanation, and context I didn't have when I was starting out. I was roughly blogging through the Rust Book, so you'll see more continuation of that soon.
-
-I hope you find something of use in my words!


### PR DESCRIPTION
Hey guys,

Have pulled my jeff-mitchell.dev blog out of production for the time being. I'm kind of re-visiting/re-homing the whole thing.

Perhaps I'll just shelve it and write directly for Shuttle more often :)

It's difficult to stay interested in writing when no one reads it.

Anyways, doing a pull request to update the "Rust as my First Language Article", didn't want broken links.

~Jeff