### PR TITLE
chore: remove blog link in introduction of the article

### DIFF
--- a/_blog/2024-11-29-the-essence-of-templating-with-tera.mdx
+++ b/_blog/2024-11-29-the-essence-of-templating-with-tera.mdx
@@ -10,7 +10,7 @@ date: '2024-11-29T00:00:00'
 
 ### Introduction
 
-Note: Interested in finding the original blog post? You can do so [here.](https://jeff-mitchell.dev/blog/2024/2024-11-23-the-essence-of-templating-with-tera/)
+For better or worse, we are in an era of client side rendered, JavaScript heavy web applications. Template rendered web sites are not in vogue as they once were. However, they still have their place and it's useful to know how to make them. Can we do a template driven web site in Rust? Why yes, yes we can. There are many crates in the Rust ecosystem, but today I'd like to take a look at Tera.
 
 [Tera](https://keats.github.io/tera/) is a powerful and flexible template engine for the Rust language. What is a template engine? Well, it's a way for you the developer to build a server side rendered web application and use templates to describe the structure and content of the app. Rather than build each page individually, using Tera you describe the overall structure and format, and the data can be dynamically pulled in on the fly.
 


### PR DESCRIPTION
Hey guys, 

Same deal with this post, took out the shameless self-promotion, as it doesn't exist anymore.

I wrote a new, short introduction for the article.

~Jeff