### PR TITLE
feat(analytics): add linkedin insight tag

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -44,6 +44,44 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe>
             `,
           }}
         />
+        <script
+          id="linkedin-partner-id"
+          dangerouslySetInnerHTML={{
+            __html: `
+              _linkedin_partner_id = "6315010";
+              window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
+              window._linkedin_data_partner_ids.push(_linkedin_partner_id);
+            `,
+          }}
+        />
+        <Script
+          id="linkedin-analytics"
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function(l) {
+                if (!l){
+                  window.lintrk = function(a,b){window.lintrk.q.push([a,b])};
+                  window.lintrk.q=[]
+                }
+                var s = document.getElementsByTagName("script")[0];
+                var b = document.createElement("script");
+                b.type = "text/javascript";
+                b.async = true;
+                b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+                s.parentNode.insertBefore(b, s);
+              })(window.lintrk);
+            `,
+          }}
+        />
+        <noscript>
+          <img
+            height="1"
+            width="1"
+            style={{ display: "none" }}
+            alt=""
+            src="https://px.ads.linkedin.com/collect/?pid=6315010&fmt=gif"
+          />
+        </noscript>
       </body>
     </Html>
   );


### PR DESCRIPTION
This pull request adds the LinkedIn Insight Tag to the global footer of the website.

The tag is inserted just before the closing `</body>` tag in `pages/_document.tsx`, ensuring it is present on every page to track conversions and enable retargeting as per LinkedIn's best practices.