### PR TITLE
Investigate and fix missing X-Frame-Options header on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,17 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "SAMEORIGIN"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "frame-ancestors 'self'"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add `vercel.json` to explicitly define `X-Frame-Options` and `Content-Security-Policy` headers, resolving their absence on Vercel deployments.

The `X-Frame-Options` header, though configured in `next.config.js`, was not consistently applied on Vercel. This change ensures these security headers are enforced at the Vercel platform level, preventing potential overrides and adding a modern CSP directive for frame protection.

---
<a href="https://cursor.com/background-agent?bcId=bc-da00454d-cddc-4061-9041-f21b8c00ebab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da00454d-cddc-4061-9041-f21b8c00ebab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

