### PR TITLE
Investigate and fix missing X-Frame-Options header on Vercel

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(_request: NextRequest) {
+  const response = NextResponse.next();
+
+  // Prefer CSP frame-ancestors; include X-Frame-Options for legacy support
+  const frameAncestors = "'self'";
+  response.headers.set(
+    "Content-Security-Policy",
+    `frame-ancestors ${frameAncestors}`
+  );
+  response.headers.set("X-Frame-Options", "SAMEORIGIN");
+
+  return response;
+}
+
+export const config = {
+  matcher: "/:path*",
+};
+

--- a/next.config.js
+++ b/next.config.js
@@ -67,20 +67,6 @@ const nextConfig = {
       },
     ];
   },
-  async headers() {
-    return [
-      {
-        // Apply these headers to all routes in your application.
-        source: "/(.*)",
-        headers: [
-          {
-            key: "X-Frame-Options",
-            value: "SAMEORIGIN",
-          },
-        ],
-      },
-    ];
-  },
   reactStrictMode: true,
   swcMinify: true,
 };


### PR DESCRIPTION
Migrate security headers to Next.js middleware to ensure consistent application on Vercel and add modern CSP `frame-ancestors`.

The `X-Frame-Options` header configured in `next.config.js` was not reliably appearing on Vercel deployments. Moving header configuration to a Next.js middleware provides a more robust and consistent way to apply these security policies across all routes, and also allows for the inclusion of the more modern `Content-Security-Policy: frame-ancestors` directive for enhanced security.

---
<a href="https://cursor.com/background-agent?bcId=bc-808cfe24-8a9f-41ac-b834-eed40f88bbaf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-808cfe24-8a9f-41ac-b834-eed40f88bbaf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

