### PR TITLE
fix: apply header overrides to the root URI too

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -71,7 +71,10 @@ const nextConfig = {
     return [
       {
         // Apply these headers to all routes in your application.
-        source: "/(.*)",
+        // Note: since i18n has been configured, the path matching rules are altered,
+        // see: https://nextjs.org/docs/app/api-reference/config/next-config-js/headers#headers-with-i18n-support
+        // That's why "/(.*)" won't match the `/`, but "/:path*" will.
+        source: "/:path*",
         headers: [
           {
             key: "X-Frame-Options",


### PR DESCRIPTION
There was a conflict between i18n settings and
path matching rules for the header overrides.

Part of PLA-338