### PR TITLE
Add link to the public templates in Console

### DIFF
--- a/components/sections/Footer.tsx
+++ b/components/sections/Footer.tsx
@@ -13,6 +13,11 @@ const SHUTTLE_LINKS = [
   { key: "features", name: "Features", href: "/#features" },
   { key: "starters", name: "Starters", href: "/starters" },
   {
+    key: "templates",
+    name: "Templates",
+    href: "https://console.shuttle.dev/templates",
+  },
+  {
     key: "releases",
     name: "Releases",
     href: "https://github.com/shuttle-hq/shuttle/releases",

--- a/components/sections/Navigation/index.tsx
+++ b/components/sections/Navigation/index.tsx
@@ -117,6 +117,12 @@ const Navigation = () => {
               text: "Careers",
               keyword: "careers",
             },
+            {
+              href: "https://console.shuttle.dev/templates",
+              event: "homepage_mainnav_templates",
+              text: "Templates",
+              keyword: "templates",
+            },
           ].map(({ event, href, text, keyword }) => (
             <LinkItem
               key={href}


### PR DESCRIPTION
Add the link to the Templates section in the Shuttle Console, which is available publicly.