### PR TITLE
feat: Add `On this page` in `BlogSidebar` (TOC)

### DIFF
--- a/_blog/2023-04-14-Shuttle-Batch-2.mdx
+++ b/_blog/2023-04-14-Shuttle-Batch-2.mdx
@@ -17,7 +17,7 @@ This got us thinking 🤔 about how we can reproduce this kind of experience and
 
 We decided to launch an experiment - Shuttle Batch 1 (a.k.a. SB-1).
 
-### **Blast Off with SB-1! 🚀**
+### Blast Off with SB-1! 🚀
 
 The first Shuttle Batch rocketed into action as a six-week online program, bringing together carefully selected Rust developers from across the globe (10 participants hailing from 8 different countries! 🌎).
 
@@ -37,7 +37,7 @@ Here's his take on the experience:
 
 We're over the moon about the outcome of the batch (esp. finding a great addition to our team) and all the glowing feedback from the batch participants - so we're doing it again! Get ready for SB-2 🎉
 
-### **Get Ready for SB-2!**
+### Get Ready for SB-2!
 
 Strap in for our upgraded and enhanced program (2.0), fine-tuned based on feedback from our fantastic first cohort while staying true to the core Batch DNA. Batch 2.0 is an 8-week online Rust program packed with entertaining experiences, designed to supercharge your learning and development journey. Prepare for:
 

--- a/_blog/2024-01-22-introducing-shuttlebytes.mdx
+++ b/_blog/2024-01-22-introducing-shuttlebytes.mdx
@@ -6,7 +6,7 @@ cover: introducing-shuttlebytes-thumb.png
 date: '2024-01-22T18:30:00'
 ---
 
-## **Introducing ShuttleBytes: bite-sized Rust tutorials**
+## Introducing ShuttleBytes: bite-sized Rust tutorials
 
 We've decided it was time to up our game and give back to the ecosystem by launching a mini series that demystifies Rust web development with an interactive, hands-on experience. Over the past 2 years, we've been doing our best to provide quality educational content to existing Rust developers and those just getting started, and this year, we want to take it to the next level.
 

--- a/_blog/2024-10-10-shuttle-redefining-backend-development.mdx
+++ b/_blog/2024-10-10-shuttle-redefining-backend-development.mdx
@@ -13,7 +13,7 @@ date: "2024-10-10T15:00:00"
 
 Today we're introducing the new Shuttle platform! We've supercharged what developers love about Shuttle, combining our powerful developer experience with enterprise-grade infrastructure. For developers, we've kept it simple and intuitive - no complex configs, just focus on your Rust code. On the production side, we've implemented VM-level isolation, increased reliability and scalability to meet real-world demands. From solo developers to enterprise teams, Shuttle now offers the perfect blend of ease and production-ready robustness.
 
-## **Our Vision**
+## Our Vision
 
 Shuttle is a new way of building and deploying cloud applications. We make dealing with cloud infrastructure simple and enjoyable so developers can focus on creating great products. Today, developers face a choice between the flexibility of large cloud providers and the simplicity of PaaS solutions, each with limitations. At Shuttle, we're forging a middle path—prioritising simplicity while preserving flexibility. Our open-source framework, [***Infrastructure from Code* (IfC)**](https://www.shuttle.dev/blog/2022/05/09/ifc), combined with our state-of-the-art platform, lets developers annotate their code to configure infrastructure and deploy instantly. IfC enables developers using GenAI to optimise cloud infrastructure setup and automate complex tasks, saving vast amounts of time.
 

--- a/_blog/2025-09-09-ai-coding-tools-rust.mdx
+++ b/_blog/2025-09-09-ai-coding-tools-rust.mdx
@@ -263,7 +263,7 @@ Now it's time to put these tools to the test by building a task management API i
 
 **Evaluation Method:** Each tool was tested with the same starting prompt. We recorded the generated code, its completeness and accuracy, and its integration into the Rust workflow.
 
-### **Building with Cursor**
+### Building with Cursor
 
 We opened a folder `rust-tasks-cursor`in Cursor, launched the **AI chat panel** (Cmd/Ctrl + L) and entered the baseline prompt:
 
@@ -331,7 +331,7 @@ Cursor then updated the `main.rs` file with the API models, handlers, and expose
 
 **Verdict:** Great for **rapid prototyping and multi-file Rust projects**, especially for developers comfortable with VS Code-style workflows.
 
-### **Building with Windsurf**
+### Building with Windsurf
 
 We created a `rust-tasks-windsurf` folder in Windsurf and used the same prompt. Windsurf scaffolded a Rust project but took longer due to its **Cascade** checks. The upside is that it proposed project structure refinements (splitting `handlers.rs` and `routes.rs`) and enforced pinned versions in `Cargo.toml`.
 
@@ -348,7 +348,7 @@ We created a `rust-tasks-windsurf` folder in Windsurf and used the same prompt. 
 
 **Verdict:** Great for **planning long-lived Rust projects** where architecture matters.
 
-### **Building with VS Code + GitHub Copilot**
+### Building with VS Code + GitHub Copilot
 
 We created a new folder `rust-tasks-copilot` in VS Code and initialized the project by running the command below:
 
@@ -371,7 +371,7 @@ Copilot helped fill in dependencies, models, and handler boilerplate as we typed
 
 **Verdict:** Great for **incremental coding and filling gaps** rather than full project generation.
 
-### **Building with Claude Code**
+### Building with Claude Code
 
 In Claude, we entered the same prompt in the terminal. Claude generated a project scaffold, listed the steps it would take, then produced `Cargo.toml` and `main.rs`. It explained async concepts and ownership trade-offs in detail while building.
 
@@ -388,7 +388,7 @@ In Claude, we entered the same prompt in the terminal. Claude generated a projec
 
 **Verdict:** Great for **learning Rust while building** (doubles as tutor + generator) **and building large-scale projects**.
 
-### **Building with Aider**
+### Building with Aider
 
 For this, we initialized Git and prompted Aider. It scaffolded a Cargo project, generated dependencies, and committed each step with descriptive messages. Its Git-aware workflow was unique: each file edit was atomic, with matching commit messages.
 

--- a/_blog/2025-09-15-mcp-servers-rust-comparison.mdx
+++ b/_blog/2025-09-15-mcp-servers-rust-comparison.mdx
@@ -34,7 +34,7 @@ Large Language Models (LLMs) such as GPT, Claude, and Gemini are powerful tools 
 
 MCP is an open standard that was introduced by Anthropic in November 2024. It enables LLMs to connect to various data sources, tools, and APIs, thereby fetching realtime information or performing tasks that exceed their built-in knowledge.
 
-### **What Makes a Good MCP for Rust Developers?**
+### What Makes a Good MCP for Rust Developers?
 
 When evaluating an MCP server for Rust development, it is essential to keep a few key criteria in mind:
 

--- a/components/blog/TableOfContents.tsx
+++ b/components/blog/TableOfContents.tsx
@@ -1,5 +1,3 @@
-import { MDXRemote } from "next-mdx-remote";
-
 interface HeaderProps {
   slug: string;
   content: string;

--- a/components/sections/BlogSidebar.tsx
+++ b/components/sections/BlogSidebar.tsx
@@ -6,6 +6,7 @@ import {
 } from "next-mdx-remote";
 import Link from "components/elements/Link";
 import { FC } from "react";
+import SidebarTOC from "./SidebarTOC";
 
 interface BlogSidebarProps {
   tags: string[];
@@ -23,6 +24,11 @@ const BlogSidebar: FC<BlogSidebarProps> = ({
   return (
     <div className="relative w-full">
       <div className="w-full space-y-6 lg:sticky lg:top-0">
+        <div className="rounded-3xl border border-black/10 px-6 py-4 dark:border-white/10">
+          <div className="mb-2 dark:text-head">On this page</div>
+          <SidebarTOC toc={toc} />
+        </div>
+
         <div className="rounded-3xl border border-black/10 px-6 py-4 dark:border-white/10">
           <div className="mb-2 dark:text-head">Categories</div>
 

--- a/components/sections/BlogSidebar.tsx
+++ b/components/sections/BlogSidebar.tsx
@@ -1,17 +1,20 @@
 import { Post } from "lib/blog/posts";
-import {
-  MDXRemote,
-  MDXRemoteProps,
-  MDXRemoteSerializeResult,
-} from "next-mdx-remote";
+import { MDXRemoteProps } from "next-mdx-remote";
 import Link from "components/elements/Link";
 import { FC } from "react";
 import SidebarTOC from "./SidebarTOC";
 
+interface TocItem {
+  slug: string;
+  content: string;
+  lvl?: number; // markdown-toc uses 'lvl'
+  level?: number; // allow 'level' just in case
+}
+
 interface BlogSidebarProps {
   tags: string[];
   relatedPosts: Post[];
-  toc?: MDXRemoteSerializeResult<Record<string, unknown>>;
+  toc?: TocItem[];
   mdxComponents: MDXRemoteProps["components"];
 }
 

--- a/components/sections/SidebarTOC.tsx
+++ b/components/sections/SidebarTOC.tsx
@@ -1,0 +1,232 @@
+import { MDXRemote, MDXRemoteSerializeResult } from "next-mdx-remote";
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+interface SidebarTOCProps {
+  toc?: MDXRemoteSerializeResult<Record<string, unknown>>;
+}
+
+// Track nesting depth of ULs to compute indentation
+const DepthContext = createContext(0);
+const ActiveIdContext = createContext<string | null>(null);
+
+function isReactElement(child: React.ReactNode): child is React.ReactElement {
+  return !!child && typeof child === "object" && "type" in (child as any);
+}
+
+const Caret: React.FC<{ open: boolean }> = ({ open }) => (
+  <svg
+    className={`h-4 w-4 shrink-0 transition-transform ${open ? "rotate-90" : "rotate-0"}`}
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden
+  >
+    <path d="M6 4l5 4-5 4V4z" fill="currentColor" />
+  </svg>
+);
+
+const TOCUl: React.FC<React.HTMLAttributes<HTMLUListElement>> = ({
+  children,
+  ...props
+}) => {
+  const depth = useContext(DepthContext);
+  const nextDepth = depth + 1;
+  return (
+    <DepthContext.Provider value={nextDepth}>
+      <ul {...props} className="my-1 space-y-1">
+        {children}
+      </ul>
+    </DepthContext.Provider>
+  );
+};
+TOCUl.displayName = "TOCUl";
+
+const TOCLi: React.FC<React.HTMLAttributes<HTMLLIElement>> = ({
+  children,
+  ...props
+}) => {
+  const depth = useContext(DepthContext);
+  const activeId = useContext(ActiveIdContext);
+  const [open, setOpen] = useState(false);
+
+  const kids = React.Children.toArray(children);
+  const hasSublist = kids.some(
+    (c) =>
+      isReactElement(c) &&
+      (c.type === "ul" ||
+        c.type === TOCUl ||
+        (c.type as any)?.displayName === "TOCUl"),
+  );
+
+  const content = useMemo(() => {
+    return kids.map((child, idx) => {
+      if (
+        isReactElement(child) &&
+        (child.type === "ul" ||
+          child.type === TOCUl ||
+          (child.type as any)?.displayName === "TOCUl")
+      ) {
+        return open ? (
+          <div key={`sub-${idx}`} className="mt-1">
+            {child}
+          </div>
+        ) : null;
+      }
+      return <React.Fragment key={idx}>{child}</React.Fragment>;
+    });
+  }, [kids, open]);
+
+  const indentPx = Math.max(0, depth - 1) * 12; // 12px per level after top
+
+  // Auto-open when the active heading is within this subtree
+  const containsActive = useMemo(() => {
+    const target = activeId ? `#${activeId}` : null;
+    if (!target) return false;
+
+    const search = (nodes: React.ReactNode[]): boolean => {
+      for (const n of nodes) {
+        if (isReactElement(n)) {
+          const t: any = n.type as any;
+          const isLink =
+            t === "a" || t === TOCLink || t?.displayName === "TOCLink";
+          if (isLink) {
+            const href = (n.props?.href as string) || "";
+            if (href === target) return true;
+          }
+          const childNodes = React.Children.toArray(n.props?.children);
+          if (childNodes.length && search(childNodes)) return true;
+        }
+      }
+      return false;
+    };
+
+    return search(kids);
+  }, [kids, activeId]);
+
+  useEffect(() => {
+    if (containsActive) setOpen(true);
+  }, [containsActive]);
+
+  return (
+    <li {...props} style={{ ...(props.style || {}) }} className="list-none">
+      <div className="flex items-start gap-2">
+        {hasSublist ? (
+          <button
+            type="button"
+            aria-label={open ? "Collapse section" : "Expand section"}
+            aria-expanded={open}
+            onClick={() => setOpen((v) => !v)}
+            className="mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center text-base hover:text-black dark:hover:text-white"
+          >
+            <Caret open={open} />
+          </button>
+        ) : (
+          // spacer to align text when there's no caret
+          <span className="mt-0.5 inline-block h-4 w-4" />
+        )}
+        <div className="min-w-0 flex-1">{content}</div>
+      </div>
+    </li>
+  );
+};
+
+// Anchor styling to match sidebar widgets (Recent articles)
+const TOCLink: React.FC<React.AnchorHTMLAttributes<HTMLAnchorElement>> = ({
+  className,
+  ...props
+}) => {
+  const activeId = useContext(ActiveIdContext);
+  const href = (props.href as string) || "";
+  const isActive = activeId && href === `#${activeId}`;
+  return (
+    <a
+      {...props}
+      className={
+        "relative left-0 text-sm transition-all duration-300 hover:left-1 " +
+        (isActive
+          ? "font-medium bg-gradient-to-r from-[#FC540C] to-[#FFD76F] bg-clip-text text-transparent "
+          : "text-slate-500 dark:text-body dark:hover:text-white ") +
+        (className ? ` ${className}` : "")
+      }
+      aria-current={isActive ? "true" : undefined}
+    />
+  );
+};
+
+export const SidebarTOC: React.FC<SidebarTOCProps> = ({ toc }) => {
+  // Track active heading based on scroll position
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const getHeadings = () =>
+      Array.from(
+        document.querySelectorAll<HTMLElement>(
+          "article h2[id], article h3[id], article h4[id], article h5[id], article h6[id]",
+        ),
+      );
+
+    const compute = () => {
+      const headings = getHeadings();
+      if (!headings.length) return;
+      const scrollY = window.scrollY || window.pageYOffset;
+      const offset = 120; // account for sticky headers
+      const current = headings
+        .map((el) => ({
+          id: el.id,
+          top: el.getBoundingClientRect().top + scrollY,
+        }))
+        .filter((h) => !!h.id)
+        .sort((a, b) => a.top - b.top)
+        .reduce<string | null>((acc, h) => {
+          return h.top <= scrollY + offset ? h.id : acc;
+        }, headings[0].id);
+      setActiveId(current);
+    };
+
+    const onScroll = () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(compute);
+    };
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+    // initial compute after paint
+    const t = setTimeout(compute, 0);
+    return () => {
+      clearTimeout(t);
+      window.removeEventListener("scroll", onScroll as any);
+      window.removeEventListener("resize", onScroll as any);
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, []);
+
+  if (!toc) return null;
+
+  return (
+    <div className="text-sm">
+      <ActiveIdContext.Provider value={activeId}>
+        <MDXRemote
+          {...toc}
+          // Override only the parts we need for a collapsible tree
+          components={{
+            ul: TOCUl,
+            li: TOCLi,
+            a: TOCLink,
+          }}
+        />
+      </ActiveIdContext.Provider>
+    </div>
+  );
+};
+
+export default SidebarTOC;

--- a/components/sections/SidebarTOC.tsx
+++ b/components/sections/SidebarTOC.tsx
@@ -129,7 +129,9 @@ const TOCLi: React.FC<React.HTMLAttributes<HTMLLIElement>> = ({
           </button>
         ) : (
           // spacer to align text when there's no caret
-          <span className="mt-0.5 inline-block h-4 w-4" />
+          <span className="mt-0.5 h-4 w-4 text-xs items-center flex justify-center text-grey700">
+            -
+          </span>
         )}
         <div className="min-w-0 flex-1">{content}</div>
       </div>

--- a/pages/blog/[year]/[month]/[day]/[slug].tsx
+++ b/pages/blog/[year]/[month]/[day]/[slug].tsx
@@ -423,7 +423,7 @@ export default function BlogPostPage(props: Props) {
           <BlogSidebar
             tags={props.blog.tags || []}
             relatedPosts={props.relatedPosts || []}
-            toc={props.blog.toc}
+            toc={props.blog.contentTOC?.json}
             mdxComponents={mdxComponents}
           />
         </div>


### PR DESCRIPTION
This PR creates table of contents section (called `On this page`) in the blog post sidebar in a form of a tree with infinite depth levels, to support sub-headers within the content.

The currently active section is highlighted while scrolling. Max depth level is set to 3 (h3).

<img width="539" height="620" alt="Screenshot 2025-09-19 at 09 51 21" src="https://github.com/user-attachments/assets/27cc94e7-d50e-41be-a1de-969acc7151d0" />

