### PR TITLE
Fix: hiding the mobile navbar on item click

### DIFF
--- a/components/elements/Link.tsx
+++ b/components/elements/Link.tsx
@@ -3,33 +3,36 @@ import NextLink, { LinkProps } from "next/link";
 import { ReactNode } from "react";
 
 interface TrackedLinkProps extends LinkProps {
-    children: ReactNode;
-    eventName?: string;
-    eventProperties?: Record<string, any>;
-    className?: string;
-    target?: string;
+  children: ReactNode;
+  eventName?: string;
+  eventProperties?: Record<string, any>;
+  className?: string;
+  target?: string;
+  onClick?: (params: any) => void;
 }
 
 const Link = ({
-    children,
-    eventName,
-    eventProperties,
-    className,
-    target,
-    ...props
+  children,
+  eventName,
+  eventProperties,
+  className,
+  target,
+  onClick,
+  ...props
 }: TrackedLinkProps) => {
-    return (
-        <NextLink
-            {...props}
-            className={className}
-            target={target}
-            onClick={() => {
-                if (eventName) trackEvent(eventName, eventProperties);
-            }}
-        >
-            {children}
-        </NextLink>
-    );
+  return (
+    <NextLink
+      {...props}
+      className={className}
+      target={target}
+      onClick={(params) => {
+        if (eventName) trackEvent(eventName, eventProperties);
+        if (onClick) onClick(params);
+      }}
+    >
+      {children}
+    </NextLink>
+  );
 };
 
 export default Link;


### PR DESCRIPTION
Currently when user clicks on menu item within the mobile navbar, the navbar itself does not hide.